### PR TITLE
Allow execution of custom scripts to install packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.tar.*
 couch
 js
+bin/extra


### PR DESCRIPTION
This change adds an ability to install additional packages useful
for development. This is done via placing additional scripts into
`bin/extra/` directory. The scripts are named based on package
manager used in a given distribution:
 - `apt-*` for apt based distributions
 - `pkg-*` for FreeBSD
 - `yum-*` - for Centos

The scripts are executed in alphabetical order.

# Testing recommendations

1. create script
    ```
    mkdir -p bin/extra
    cat << EOF > bin/extra/apt-rg.sh
    curl -LO https://github.com/BurntSushi/ripgrep/releases/download/0.8.1/ripgrep_0.8.1_amd64.deb
    sudo dpkg -i ripgrep_0.8.1_amd64.deb
    EOF
    chmod +x bin/extra/apt-rg.sh
    ```
2. Build platform `./build.sh platform debian-stretch`
3. Check the logs you should see following:
    ```
    Preparing to unpack ripgrep_0.8.1_amd64.deb ...
    Unpacking ripgrep (0.8.1) ...
    Setting up ripgrep (0.8.1) ...
    ```
4. Run container 
    ```
    docker run -it couchdbdev/debian-stretch-erlang-19.3.6 bash
    ```
5. Check that `rg` is available
    ``` 
    which rg
    /usr/local/bin/rg
    ```