### PR TITLE
Split platforms into separate Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,18 @@ before_script:
 
 env:
   matrix:
-    - TARGET=js-all
-    - TARGET=couch-pkg-all
+    - PLATFORM=debian-jessie
+    - PLATFORM=debian-stretch
+    - PLATFORM=ubuntu-trusty
+    - PLATFORM=ubuntu-xenial
+    - PLATFORM=ubuntu-bionic
+    - PLATFORM=centos-6
+    - PLATFORM=centos-7
 
 script:
-  - ./build.sh ${TARGET}
+  - ./build.sh js ${PLATFORM}
+  - ./build.sh couch-pkg ${PLATFORM}
+
+after_script:
+  - ls -laR js
+  - ls -laR couch


### PR DESCRIPTION
This should fix when Travis kills the build for running too long, at the expense of us needing 7 or more separate build targets.