### PR TITLE
[deb] Fix lintian rules so package builds succeed

### DIFF
--- a/bin/apt-dependencies.sh
+++ b/bin/apt-dependencies.sh
@@ -101,8 +101,18 @@ mkdir -p /usr/share/lintian/profiles/couchdb
 chmod 0755 /usr/share/lintian/profiles/couchdb
 if [[ ${VERSION} =~ ${debians} ]]; then
   cp ${SCRIPTPATH}/../files/debian.profile /usr/share/lintian/profiles/couchdb/main.profile
+  if [[ ${VERSION} == "jessie" ]]; then
+    # remove unknown lintian rule privacy-breach-uses-embedded-file
+    sed -i -e 's/, privacy-breach-uses-embedded-file//' /usr/share/lintian/profiles/couchdb/main.profile
+    # add rule to suppress python-script-but-no-python-dep
+    sed -i -e 's/Disable-Tags: /Disable-Tags: python-script-but-no-python-dep, /' /usr/share/lintian/profiles/couchdb/main.profile
+  fi
 elif [[ ${VERSION} =~ ${ubuntus} ]]; then
   cp ${SCRIPTPATH}/../files/ubuntu.profile /usr/share/lintian/profiles/couchdb/main.profile
+  if [[ ${VERSION} == "xenial" ]]; then
+    # add rule to suppress python-script-but-no-python-dep
+    sed -i -e 's/Disable-Tags: /Disable-Tags: python-script-but-no-python-dep, /' /usr/share/lintian/profiles/couchdb/main.profile
+  fi
 else
   echo "Unrecognized Debian-like release: ${VERSION}! Skipping lintian work."
 fi

--- a/files/debian.profile
+++ b/files/debian.profile
@@ -1,3 +1,3 @@
 Profile: couchdb/main
 Extends: debian/main
-Disable-Tags: dir-or-file-in-opt, source-is-missing, non-etc-file-marked-as-conffile, embedded-library, duplicate-font-file, embedded-javascript-library, depends-on-essential-package-without-using-version
+Disable-Tags: dir-or-file-in-opt, source-is-missing, non-etc-file-marked-as-conffile, embedded-library, duplicate-font-file, embedded-javascript-library, depends-on-essential-package-without-using-version, privacy-breach-uses-embedded-file

--- a/files/ubuntu.profile
+++ b/files/ubuntu.profile
@@ -1,3 +1,3 @@
 Profile: couchdb/main
 Extends: ubuntu/main
-Disable-Tags: dir-or-file-in-opt, source-is-missing, non-etc-file-marked-as-conffile, embedded-library, depends-on-essential-package-without-using-version
+Disable-Tags: dir-or-file-in-opt, source-is-missing, non-etc-file-marked-as-conffile, embedded-library, depends-on-essential-package-without-using-version, privacy-breach-uses-embedded-file


### PR DESCRIPTION
These changes globally ignore some new lintian errors, as well as manually tweak those rules for specific platforms where the rules are too new (jessie) or the rule is falsely triggered (jessie, xenial).