### PR TITLE
Split Travis into 3x the jobs (js, couch, couch-pkg)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,73 @@
 sudo: required
 
+language: minimal
+
+# Avoid double build on PRs (See https://github.com/travis-ci/travis-ci/issues/1147)
+branches:
+  only:
+    - master
+
 services:
   - docker
 
-before_script:
-  - docker --version
-
 env:
-  matrix:
-    - PLATFORM=debian-jessie
-    - PLATFORM=debian-stretch
-    - PLATFORM=ubuntu-trusty
-    - PLATFORM=ubuntu-xenial
-    - PLATFORM=ubuntu-bionic
-    - PLATFORM=centos-6
-    - PLATFORM=centos-7
+  global:
+    - TARBALL_URL=https://dist.apache.org/repos/dist/release/couchdb/source/2.2.0/apache-couchdb-2.2.0.tar.gz
+    - TARBALL=apache-couchdb-2.2.0.tar.gz
+
+matrix:
+  include:
+    - name: "debian-jessie js"
+      env: PLATFORM=debian-jessie TARGET=js
+    - name: "debian-jessie couch"
+      env: PLATFORM=debian-jessie TARGET=couch
+    - name: "debian-jessie couch-pkg"
+      env: PLATFORM=debian-jessie TARGET=couch-pkg
+    - name: "debian-stretch js"
+      env: PLATFORM=debian-stretch TARGET=js
+    - name: "debian-stretch couch"
+      env: PLATFORM=debian-stretch TARGET=couch
+    - name: "debian-stretch couch-pkg"
+      env: PLATFORM=debian-stretch TARGET=couch-pkg
+    - name: "ubuntu-trusty js"
+      env: PLATFORM=ubuntu-trusty TARGET=js
+    - name: "ubuntu-trusty couch"
+      env: PLATFORM=ubuntu-trusty TARGET=couch
+    - name: "ubuntu-trusty couch-pkg"
+      env: PLATFORM=ubuntu-trusty TARGET=couch-pkg
+    - name: "ubuntu-xenial js"
+      env: PLATFORM=ubuntu-xenial TARGET=js
+    - name: "ubuntu-xenial couch"
+      env: PLATFORM=ubuntu-xenial TARGET=couch
+    - name: "ubuntu-xenial couch-pkg"
+      env: PLATFORM=ubuntu-xenial TARGET=couch-pkg
+    - name: "ubuntu-bionic js"
+      env: PLATFORM=ubuntu-bionic TARGET=js
+    - name: "ubuntu-bionic couch"
+      env: PLATFORM=ubuntu-bionic TARGET=couch
+    - name: "ubuntu-bionic couch-pkg"
+      env: PLATFORM=ubuntu-bionic TARGET=couch-pkg
+    - name: "centos-6 js"
+      env: PLATFORM=centos-6 TARGET=js
+    - name: "centos-6 couch"
+      env: PLATFORM=centos-6 TARGET=couch
+    - name: "centos-6 couch-pkg"
+      env: PLATFORM=centos-6 TARGET=couch-pkg
+    - name: "centos-7 js"
+      env: PLATFORM=centos-7 TARGET=js
+    - name: "centos-7 couch"
+      env: PLATFORM=centos-7 TARGET=couch
+    - name: "centos-7 couch-pkg"
+      env: PLATFORM=centos-7 TARGET=couch-pkg
+
+before_install:
+  - docker --version
+  - if [[ ${TARGET} == "js" ]]; then docker pull couchdbdev/${PLATFORM}-base; fi
+  - if [[ ${TARGET} == "couch-pkg" ]]; then wget ${TARBALL_URL}; fi
+  - if [[ ${TARGET} == "couch-pkg" ]]; then docker pull couchdbdev/${PLATFORM}-erlang-19.3.6; fi
 
 script:
-  - ./build.sh js ${PLATFORM}
-  - ./build.sh couch-pkg ${PLATFORM}
+  - if [[ ${TARGET} == "couch-pkg" ]]; then ./build.sh ${TARGET} ${PLATFORM} ${TARBALL}; else ./build.sh ${TARGET} ${PLATFORM}; fi
 
 after_script:
-  - ls -laR js
-  - ls -laR couch
+  - ls -laR js couch

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ CouchDB's CI build philosophy is to use Travis (with `kerl`) to validate CouchDB
 
 For those OSes that support Docker, we run builds inside of Docker containers. These containers are built using the `build.sh` command at the root level.
 
-Separate targets exist to build a compatible SpiderMonkey 1.8.5 package for each Linux target release.
+Separate targets exist to build a compatible SpiderMonkey 1.8.5 package for each Linux target release, known as the `-base` image.
 
 ## Building a container
 
@@ -36,6 +36,8 @@ Separate targets exist to build a compatible SpiderMonkey 1.8.5 package for each
 Valid `distro` and `version` values come from the table above.
 
 ## Building the special Debian Jessie 17.5.3 image
+
+We use this image to build the initial tarball, before running the build test on other platforms. We do this because we want to generate a `rebar` binary compatible with all versions of Erlang we support. If we do this on too new a version, older Erlangs won't recognize it. At present, Erlang 17 is the oldest version we still support.
 
 ```
 ERLANGVERSION=17.5.3 ./build.sh platform debian-jessie
@@ -55,27 +57,37 @@ ERLANGVERSION=17.5.3 ./build.sh platform debian-jessie
 ## Full `build.sh` options
 
 ```
+./build.sh <command> [OPTIONS]
+
 Recognized commands:
-  clean <plat>		Removes all images for <plat>.
-  clean-all		Cleans all images for all platforms.
-  base <plat>		Builds the base (no JS/Erlang) image for <plat>.
-  base-all		Builds all base (no JS/Erlang) images.
-  js			Builds the JS packages for <plat>.
-  js-all		Builds the JS packages for all platforms.
-  js-no-rebuild		Builds the JS packages for <plat> without rebuilding
-                	the base image first.
-  js-all-no-rebuild	Same as above, with the same condition.
-  js-upload <plat>	Uploads the JS packages for <plat> to bintray.
-			Requires BINTRAY_USER and BINTRAY_API_KEY env vars.
-  platform <plat>	Builds the image for <plat> with Erlang & JS support.
-  platform-all		Builds all images with Erlang and JS support.
-  platform-upload	Uploads the couchdbdev/* images to Docker Hub.
-			Requires appropriate credentials.
-  platform-upload-all	Uploads all the couchdbdev/* images to Docker Hub.
-  couch <plat>		Builds and tests CouchDB for <plat>.
-  couch-all		Builds and tests CouchDB on all platforms.
-  couch-pkg <plat>	Builds CouchDB packages for <plat>.
-  couch-pkg-all		Builds CouchDB packages for all platforms.
+  clean <plat>          Removes all images for <plat>.
+  clean-all             Cleans all images for all platforms.
+
+  base <plat>           Builds the base (no JS/Erlang) image for <plat>.
+  base-all              Builds all base (no JS/Erlang) images.
+  base-upload           Uploads the couchdbdev/*-base images to Docker Hub.
+                        Requires appropriate credentials.
+  base-upload-all       Uploads all the couchdbdev/*-base images.
+
+  js                    Builds the JS packages for <plat>.
+  js-all                Builds the JS packages for all platforms.
+  js-no-rebuild         Builds the JS packages for <plat> without rebuilding
+                        the base image first.
+  js-all-no-rebuild     Same as above, with the same condition.
+  js-upload <plat>      Uploads the JS packages for <plat> to bintray.
+                        Requires BINTRAY_USER and BINTRAY_API_KEY env vars.
+
+  platform <plat>       Builds the image for <plat> with Erlang & JS support.
+  platform-all          Builds all images with Erlang and JS support.
+  platform-upload       Uploads the couchdbdev/*-erlang-* images to Docker Hub.
+                        Requires appropriate credentials.
+  platform-upload-all   Uploads all the couchdbdev/*-erlang-* images to Docker.
+
+  couch <plat>          Builds and tests CouchDB for <plat>.
+  couch-all             Builds and tests CouchDB on all platforms.
+
+  couch-pkg <plat>      Builds CouchDB packages for <plat>.
+  couch-pkg-all         Builds CouchDB packages for all platforms.
 ```
 
 ## Interactively working in a built container

--- a/build.sh
+++ b/build.sh
@@ -57,6 +57,16 @@ build-base-platform() {
       ${SCRIPTPATH}
 }
 
+upload-base() {
+  if [[ ! ${DOCKER_ID_USER} ]]; then
+    echo "Please set your Docker credentials before using this command:"
+    echo "  export DOCKER_ID_USER=<username>"
+    echo "  docker login"
+    exit 1
+  fi
+  docker push couchdbdev/$1-base
+}
+
 build-js() {
   # TODO: check if image is built first, if not, complain
   # invoke as build-js <plat>
@@ -214,6 +224,16 @@ case "$1" in
       build-base-platform $plat $*
     done
     ;;
+  base-upload)
+    shift
+    upload-base $plat $*
+    ;;
+  base-upload-all)
+    shift
+    for plat in $DEBIANS $UBUNTUS $CENTOSES; do
+      upload-base $plat $*
+    done
+    ;;
   js)
     # Build js packages for a given platform
     shift
@@ -307,6 +327,9 @@ Recognized commands:
 
   base <plat>		Builds the base (no JS/Erlang) image for <plat>.
   base-all		Builds all base (no JS/Erlang) images.
+  base-upload           Uploads the couchdbdev/*-base images to Docker Hub.
+			Requires appropriate credentials.
+  base-upload-all       Uploads all the couchdbdev/*-base images.
 
   js			Builds the JS packages for <plat>.
   js-all		Builds the JS packages for all platforms.
@@ -318,10 +341,9 @@ Recognized commands:
 
   platform <plat>	Builds the image for <plat> with Erlang & JS support.
   platform-all		Builds all images with Erlang and JS support.
-
-  platform-upload	Uploads the couchdbdev/* images to Docker Hub.
+  platform-upload	Uploads the couchdbdev/*-erlang-* images to Docker Hub.
 			Requires appropriate credentials.
-  platform-upload-all	Uploads all the couchdbdev/* images to Docker Hub.
+  platform-upload-all	Uploads all the couchdbdev/*-erlang-* images to Docker.
 
   couch <plat>		Builds and tests CouchDB for <plat>.
   couch-all		Builds and tests CouchDB on all platforms.


### PR DESCRIPTION
Over in #4 we are seeing Travis build timeouts due to the length of time it takes to build, test and package CouchDB in a single Travis job.

This splits out Travis config into a matrix of platform vs. target. All of the currently supported platforms are in the matrix. The three targets are:
* `js` (build JavaScript package)
* `couch` (build and test CouchDB)
* `couch-pkg` (build the CouchDB pkgs from a dist tarball)

To simplify things, `couch-pkg` uses the official 2.2.0 dist tarball.

This is a lot more jobs (21 vs. 7) but I expect this repo to change very infrequently. Depending on how much parallelism Travis CI gives to Apache, this may even run faster than the old configuration.