### PR TITLE
[deb] add python3-venv pkg, see apache/couchdb#1764

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,44 +17,58 @@ env:
 
 matrix:
   include:
-    - name: "debian-jessie js"
-      env: PLATFORM=debian-jessie TARGET=js
+    - name: "debian-jessie base"
+      env: PLATFORM=debian-jessie TARGET=base
+    - name: "debian-jessie js-no-rebuild"
+      env: PLATFORM=debian-jessie TARGET=js-no-rebuild
     - name: "debian-jessie couch"
       env: PLATFORM=debian-jessie TARGET=couch
     - name: "debian-jessie couch-pkg"
       env: PLATFORM=debian-jessie TARGET=couch-pkg
-    - name: "debian-stretch js"
-      env: PLATFORM=debian-stretch TARGET=js
+    - name: "debian-stretch base"
+      env: PLATFORM=debian-stretch TARGET=base
+    - name: "debian-stretch js-no-rebuild"
+      env: PLATFORM=debian-stretch TARGET=js-no-rebuild
     - name: "debian-stretch couch"
       env: PLATFORM=debian-stretch TARGET=couch
     - name: "debian-stretch couch-pkg"
       env: PLATFORM=debian-stretch TARGET=couch-pkg
-    - name: "ubuntu-trusty js"
-      env: PLATFORM=ubuntu-trusty TARGET=js
+    - name: "ubuntu-trusty base"
+      env: PLATFORM=ubuntu-trusty TARGET=base
+    - name: "ubuntu-trusty js-no-rebuild"
+      env: PLATFORM=ubuntu-trusty TARGET=js-no-rebuild
     - name: "ubuntu-trusty couch"
       env: PLATFORM=ubuntu-trusty TARGET=couch
     - name: "ubuntu-trusty couch-pkg"
       env: PLATFORM=ubuntu-trusty TARGET=couch-pkg
-    - name: "ubuntu-xenial js"
-      env: PLATFORM=ubuntu-xenial TARGET=js
+    - name: "ubuntu-xenial base"
+      env: PLATFORM=ubuntu-xenial TARGET=base
+    - name: "ubuntu-xenial js-no-rebuild"
+      env: PLATFORM=ubuntu-xenial TARGET=js-no-rebuild
     - name: "ubuntu-xenial couch"
       env: PLATFORM=ubuntu-xenial TARGET=couch
     - name: "ubuntu-xenial couch-pkg"
       env: PLATFORM=ubuntu-xenial TARGET=couch-pkg
-    - name: "ubuntu-bionic js"
-      env: PLATFORM=ubuntu-bionic TARGET=js
+    - name: "ubuntu-bionic base"
+      env: PLATFORM=ubuntu-bionic TARGET=base
+    - name: "ubuntu-bionic js-no-rebuild"
+      env: PLATFORM=ubuntu-bionic TARGET=js-no-rebuild
     - name: "ubuntu-bionic couch"
       env: PLATFORM=ubuntu-bionic TARGET=couch
     - name: "ubuntu-bionic couch-pkg"
       env: PLATFORM=ubuntu-bionic TARGET=couch-pkg
-    - name: "centos-6 js"
-      env: PLATFORM=centos-6 TARGET=js
+    - name: "centos-6 base"
+      env: PLATFORM=centos-6 TARGET=base
+    - name: "centos-6 js-no-rebuild"
+      env: PLATFORM=centos-6 TARGET=js-no-rebuild
     - name: "centos-6 couch"
       env: PLATFORM=centos-6 TARGET=couch
     - name: "centos-6 couch-pkg"
       env: PLATFORM=centos-6 TARGET=couch-pkg
-    - name: "centos-7 js"
-      env: PLATFORM=centos-7 TARGET=js
+    - name: "centos-7 base"
+      env: PLATFORM=centos-7 TARGET=base
+    - name: "centos-7 js-no-rebuild"
+      env: PLATFORM=centos-7 TARGET=js-no-rebuild
     - name: "centos-7 couch"
       env: PLATFORM=centos-7 TARGET=couch
     - name: "centos-7 couch-pkg"
@@ -62,7 +76,7 @@ matrix:
 
 before_install:
   - docker --version
-  - if [[ ${TARGET} == "js" ]]; then docker pull couchdbdev/${PLATFORM}-base; fi
+  - if [[ ${TARGET} == "js-no-rebuild" ]]; then docker pull couchdbdev/${PLATFORM}-base; fi
   - if [[ ${TARGET} == "couch-pkg" ]]; then wget ${TARBALL_URL}; fi
   - if [[ ${TARGET} == "couch-pkg" ]]; then docker pull couchdbdev/${PLATFORM}-erlang-19.3.6; fi
 

--- a/bin/apt-dependencies.sh
+++ b/bin/apt-dependencies.sh
@@ -60,11 +60,23 @@ fi
 apt-get -y dist-upgrade
 
 # install build-time dependencies
+if [[ ${VERSION} == "trusty" ]]; then
+  VENV=python3.4-venv
+else
+  VENV=python3-venv
+fi
+
+# build deps, doc build deps, pkg building, then userland helper stuff
 apt-get install -y apt-transport-https curl git pkg-config \
-    python3 libpython3-dev python3-pip \
+    python3 libpython3-dev python3-pip ${VENV} \
     sudo wget zip unzip \
     build-essential ca-certificates libcurl4-openssl-dev \
-    libicu-dev libnspr4-dev
+    libicu-dev libnspr4-dev \
+    help2man python3-sphinx \
+    curl debhelper devscripts dh-exec dh-python \
+    dialog equivs lintian libwww-perl quilt \
+    reprepro createrepo \
+    vim-tiny screen
 
 # Node.js
 pushd /tmp
@@ -74,9 +86,6 @@ apt-get install -y nodejs
 rm setup_${NODEVERSION}.x
 popd
 
-# documentation packages
-apt-get install -y help2man python-sphinx
-
 # fix for broken sphinx on ubuntu 12.04 only
 if [[ ${VERSION} == "precise" ]]; then
   pip3 install docutils==0.13.1 sphinx==1.5.3
@@ -85,17 +94,10 @@ fi
 # rest of python dependencies
 pip3 install --upgrade sphinx_rtd_theme nose requests hypothesis==3.79.0
 
-# package-building stuff
-apt-get install -y curl debhelper devscripts dh-exec dh-python \
-    dialog equivs lintian libwww-perl quilt
-
 # install dh-systemd if available
 if [[ ${VERSION} != "precise" ]]; then
   apt-get install -y dh-systemd
 fi
-
-# Stuff to make Debian and RPM repositories
-apt-get install -y reprepro createrepo
 
 # relaxed lintian rules for CouchDB
 mkdir -p /usr/share/lintian/profiles/couchdb
@@ -118,9 +120,6 @@ else
   echo "Unrecognized Debian-like release: ${VERSION}! Skipping lintian work."
 fi
 chmod 0644 /usr/share/lintian/profiles/couchdb/main.profile
-
-# convenience stuff for the CI workflow maintainer ;)
-apt-get install -y vim-tiny screen
 
 # js packages, as long as we're not told to skip them
 if [[ $1 != "nojs" ]]; then


### PR DESCRIPTION
To match what we just did for needs in apache/couchdb#1764. Ironically the "easiest on all OSes" requires this pkg install on Debian/Ubuntu.

I'll leave `python3-virtualenv` in there for now, it won't hurt anything.