### PR TITLE
Bump elixir from 1.6.6 to 1.7.4

### DIFF
--- a/bin/install-elixir.sh
+++ b/bin/install-elixir.sh
@@ -28,7 +28,7 @@
 set -e
 
 ELIXIR_PACKAGES=https://github.com/elixir-lang/elixir/releases/download
-ELIXIR_VSN=${ELIXIRVERSION:-v1.6.6}
+ELIXIR_VSN=${ELIXIRVERSION:-v1.7.4}
 
 # Check if running as root
 if [[ ${EUID} -ne 0 ]]; then


### PR DESCRIPTION
Erlang 22 travis builds need 1.7.4 to run

Issue: https://github.com/apache/couchdb/issues/2069