### PR TITLE
Add debian buster, drop debian jessie/ubuntu trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,16 @@ branches:
 
 env:
   matrix:
-    - PLATFORM=debian-jessie TARGET=base
-    - PLATFORM=debian-jessie TARGET=platform
-    - PLATFORM=debian-jessie TARGET=couch
     - PLATFORM=debian-stretch TARGET=base
     - PLATFORM=debian-stretch TARGET=platform
     - PLATFORM=debian-stretch TARGET=couch
     - PLATFORM=aarch64-debian-stretch TARGET=base
-    - ERLANGVERSION=20.3.8.20 PLATFORM=aarch64-debian-stretch TARGET=platform
-    - ERLANGVERSION=20.3.8.20 PLATFORM=aarch64-debian-stretch TARGET=couch
+    # too slow!
+    #- ERLANGVERSION=20.3.8.20 PLATFORM=aarch64-debian-stretch TARGET=platform
+    #- ERLANGVERSION=20.3.8.20 PLATFORM=aarch64-debian-stretch TARGET=couch
+    - PLATFORM=debian-buster TARGET=base
+    - ERLANGVERSION=20.3.8.22-1 PLATFORM=debian-buster TARGET=platform
+    - ERLANGVERSION=20.3.8.22-1 PLATFORM=debian-buster TARGET=couch
     - PLATFORM=ubuntu-xenial TARGET=base
     - PLATFORM=ubuntu-xenial TARGET=platform
     - PLATFORM=ubuntu-xenial TARGET=couch

--- a/README.md
+++ b/README.md
@@ -12,15 +12,13 @@ These images are used by [Apache Jenkins CI](https://builds.apache.org/blue/orga
 
 CouchDB's CI build philosophy is to use Travis (with `kerl`) to validate CouchDB against different Erlang versions, and to use Jenkins to validate CouchDB against different OSes and architectures. Where possible, Jenkins also auto-builds convenience binaries or packages. The eventual goal is that these auto-built binaries/packages/Docker images will be auto-pushed to our distribution repos for downstream consumption.
 
-# Supported Configurations (updated 2018-12-05)
+# Supported Configurations (updated 2019-08-22)
 
 **OS / distro** | **Version** | **Erlang Version** | **Architecture** | **Docker?**
 ----------------|-------------|--------------------|------------------|--------------------
-**debian**      | jessie      | 17.5.3             | `x86_64`         | :heavy_check_mark:
-**debian**      | jessie      | 19.3.6             | `x86_64`         | :heavy_check_mark:
 **debian**      | stretch     | 19.3.6             | `x86_64`         | :heavy_check_mark:
 **debian**      | stretch     | 19.3.6             | `aarch64`        | :heavy_check_mark:
-**ubuntu**      | trusty      | 19.3.6             | `x86_64`         | :heavy_check_mark:
+**debian**      | buster      | 20.3.8.22          | `x86_64`         | :heavy_check_mark:
 **ubuntu**      | xenial      | 19.3.6             | `x86_64`         | :heavy_check_mark:
 **ubuntu**      | bionic      | 19.3.6             | `x86_64`         | :heavy_check_mark:
 **centos**      | 6           | 19.3.6             | `x86_64`         | :heavy_check_mark:
@@ -54,9 +52,11 @@ Build a platform image with:
 ./build.sh platform <distro>-<version>
 ```
 
-## Building the special Debian Jessie 17.5.3 `x86_64` image
+## Building a special old Erlang version image
 
-We use this image to build the initial tarball, before running the build test on other platforms. We do this because we want to generate a `rebar` binary compatible with all versions of Erlang we support. If we do this on too new a version, older Erlangs won't recognize it. At present, Erlang 17 is the oldest version we still support.
+Previously, we used this image to build the initial tarball, before running the build test on other platforms. We do this because we want to generate a `rebar` binary compatible with all versions of Erlang we support. If we do this on too new a version, older Erlangs won't recognize it.
+
+At present, Erlang 19 is the oldest version we still support, so this image isn't used anymore, and isn't strictly supported anymore either, but should still work.
 
 The build command is:
 ```
@@ -68,7 +68,7 @@ ERLANGVERSION=17.5.3 ./build.sh platform debian-jessie
 1.  You need a Docker Cloud account with access to the `couchdbdev` organization. Ask the CouchDB PMC for assistance with this.
 2. `export DOCKER_ID_USER="username"`
 3. `docker login` and enter your password.
-4. `./build.sh publish <distro>-<version>` just as above.
+4. `./build.sh platform-upload <distro>-<version>` just as above.
 
 ---
 

--- a/dockerfiles/debian-buster
+++ b/dockerfiles/debian-buster
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing,
+#   software distributed under the License is distributed on an
+#   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#   KIND, either express or implied.  See the License for the
+#   specific language governing permissions and limitations
+
+# NOTE: These are intended to be built using the arguments as
+# described in ../build.sh. See that script for more details.
+
+FROM debian:buster
+
+# Choose whether to install SpiderMonkey 1.8.5, default yes
+ARG js=js
+# Choose whether to install Erlang, default yes
+ARG erlang=erlang
+# Select version of Node, Erlang and Elixir to install
+ARG erlangversion=20.3.8.22-1
+ARG elixirversion=v1.6.6
+ARG nodeversion=10
+
+# Create Jenkins user and group
+RUN groupadd --gid 910 jenkins; \
+  useradd --uid 910 --gid jenkins --create-home jenkins
+
+# Copy couchdb-ci repo into root's home directory
+ADD --chown=root:root bin /root/couchdb-ci/bin/
+ADD --chown=root:root files /root/couchdb-ci/files/
+
+# Jenkins builds in /usr/src/couchdb.
+RUN mkdir -p /usr/src/couchdb; \
+  chown -R jenkins:jenkins /usr/src/couchdb
+
+# Install all dependencies, and optionally SM 1.8.5
+# This allows us to use the same Dockerfile for building SM
+RUN ERLANGVERSION=$erlangversion \
+  ELIXIRVERSION=$elixirversion \
+  NODEVERSION=$nodeversion \
+  /root/couchdb-ci/bin/install-dependencies.sh $js $erlang
+
+# Allow Jenkins to sudo
+RUN echo "jenkins ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/jenkins
+
+USER jenkins
+
+# overwrite this with 'CMD []' in a dependent Dockerfile
+CMD ["/bin/bash"]

--- a/files/debian.profile
+++ b/files/debian.profile
@@ -1,3 +1,3 @@
 Profile: couchdb/main
 Extends: debian/main
-Disable-Tags: dir-or-file-in-opt, source-is-missing, non-etc-file-marked-as-conffile, embedded-library, duplicate-font-file, embedded-javascript-library, depends-on-essential-package-without-using-version, privacy-breach-uses-embedded-file
+Disable-Tags: dir-or-file-in-opt, source-is-missing, non-etc-file-marked-as-conffile, embedded-library, duplicate-font-file, embedded-javascript-library, depends-on-essential-package-without-using-version, privacy-breach-uses-embedded-file, hardening-no-pie, binary-or-shlib-defines-rpath


### PR DESCRIPTION
## Overview

* Adds Debian buster CI support
* Officially drops Debian jessie / Ubuntu trusty support
* Lintian fixes from new Debian buster

## Testing recommendations

Travis will do it, but:

```
- ./build.sh base debian-buster
- ERLANGVERSION=20.3.8.22-1 ./build.sh platform debian-buster
- ERLANGVERSION=20.3.8.22-1 ./build.sh couchdb debian-buster
```

## GitHub issue number

related to apache/couchdb-ci#47

## Related Pull Requests

One shortly to follow in couchdb-pkg

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [X] Documentation reflects the changes;
