### PR TITLE
Improvements to multi-architecture builds, arbitrary Erlang, bump default versions

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -28,12 +28,10 @@
 # stop on error
 set -e
 
-# Node 8 as of 2018-05-08
-NODEVERSION=${NODEVERSION:-8}
-# Erlang 19.3.6 as of 2018-05-08
-ERLANGVERSION=${ERLANGVERSION:-19.3.6}
-# Elixir v1.6.6 as of 2018-07-25
-ELIXIRVERSION=${ELIXIRVERSION:-v1.6.6}
+# Defaults updated 2019-10-14
+NODEVERSION=${NODEVERSION:-10}
+ERLANGVERSION=${ERLANGVERSION:-20.3.8.22}
+ELIXIRVERSION=${ELIXIRVERSION:-v1.9.1}
 
 
 # This works if we're not called through a symlink

--- a/bin/source-erlang.sh
+++ b/bin/source-erlang.sh
@@ -46,7 +46,7 @@ latest='(stretch|buster|bionic)'
 #  http://docs.basho.com/riak/1.3.0/tutorials/installation/Installing-Erlang/
 # NB: Dropping suggested superfluous packages; fop and unixodbc-dev
 if [[ ${ID} =~ ${redhats} ]]; then
-    yum install git gcc glibc-devel make ncurses-devel openssl-devel autoconf
+    yum install -y git gcc glibc-devel make ncurses-devel openssl-devel autoconf
 elif [[ ${ID} =~ ${debians} ]]; then
     if [[ ${ERLANGVERSION%%.*} -le 19 ]] && [[ ${VERSION_CODENAME} =~ ${latest} ]]; then
 	echo "Recent versions of Linux (Stretch, Bionic, etc) provide a version of libssl"

--- a/build.sh
+++ b/build.sh
@@ -36,28 +36,36 @@ SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # platforms, go to dockerfiles/* and update all the files
 # there...but be aware Erlang packages may be missing on
 # some platforms!
-if [ ! -z "${NODEVERSION}" ]
-then
-  buildargs="$buildargs --build-arg nodeversion=${NODEVERSION} "
-fi
-if [ ! -z "${ERLANGVERSION}" ]
-then
-  buildargs="$buildargs --build-arg erlangversion=${ERLANGVERSION} "
-fi
-if [ ! -z "${ELIXIRVERSION}" ]
-then
-  buildargs="$buildargs --build-arg elixirversion=${ELIXIRVERSION} "
-fi
 
-DEBIANS="debian-stretch aarch64-debian-stretch debian-buster"
+DEBIANS="debian-stretch debian-buster"
 UBUNTUS="ubuntu-xenial ubuntu-bionic"
-debs="(debian-stretch|aarch64-debian-stretch|debian-buster|ubuntu-xenial|ubuntu-bionic)"
+debs="(debian-stretch|debian-buster|ubuntu-xenial|ubuntu-bionic)"
 
 CENTOSES="centos-6 centos-7"
 rpms="(centos-6|centos-7)"
 
 BINTRAY_API="https://api.bintray.com"
 
+
+check-envs() {
+  if [ ! -z "${NODEVERSION}" ]
+  then
+    buildargs="$buildargs --build-arg nodeversion=${NODEVERSION} "
+  fi
+  if [ ! -z "${ERLANGVERSION}" ]
+  then
+    buildargs="$buildargs --build-arg erlangversion=${ERLANGVERSION} "
+  fi
+  if [ ! -z "${ELIXIRVERSION}" ]
+  then
+    buildargs="$buildargs --build-arg elixirversion=${ELIXIRVERSION} "
+  fi
+  if [ ! -z "${CONTAINERARCH}" ]
+  then
+    buildargs="$buildargs --build-arg containerarch=${CONTAINERARCH} "
+    CONTAINERARCH="${CONTAINERARCH}-"
+  fi
+}
 
 build-base-platform() {
   # invoke as build-base <plat>
@@ -66,7 +74,7 @@ build-base-platform() {
       --build-arg js=nojs \
       --build-arg erlang=noerlang \
       $buildargs \
-      --tag couchdbdev/$1-base \
+      --tag couchdbdev/${CONTAINERARCH}$1-base \
       ${SCRIPTPATH}
 }
 
@@ -91,7 +99,7 @@ build-platform() {
   find-erlang-version $1
   docker build -f dockerfiles/$1 \
       $buildargs \
-      --tag couchdbdev/$1-erlang-${ERLANGVERSION} \
+      --tag couchdbdev/${CONTAINERARCH}$1-erlang-${ERLANGVERSION} \
       ${SCRIPTPATH}
 }
 
@@ -126,6 +134,10 @@ build-test-couch() {
       /home/jenkins/couchdb-ci/bin/build-test-couchdb.sh $2
 }
 
+
+# #######################
+
+check-envs
 
 case "$1" in
   clean)

--- a/dockerfiles/centos-6
+++ b/dockerfiles/centos-6
@@ -24,9 +24,9 @@ ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
-ARG erlangversion=19.3.6
-ARG elixirversion=v1.6.6
-ARG nodeversion=8
+ARG erlangversion=20.3.8.22-1
+ARG elixirversion=v1.9.1
+ARG nodeversion=10
 
 # Create Jenkins user and group
 RUN groupadd --gid 910 jenkins; \

--- a/dockerfiles/centos-7
+++ b/dockerfiles/centos-7
@@ -24,9 +24,9 @@ ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
-ARG erlangversion=19.3.6
-ARG elixirversion=v1.6.6
-ARG nodeversion=8
+ARG erlangversion=20.3.8.22-1
+ARG elixirversion=v1.9.1
+ARG nodeversion=10
 
 # Create Jenkins user and group
 RUN groupadd --gid 910 jenkins; \

--- a/dockerfiles/centos-8
+++ b/dockerfiles/centos-8
@@ -17,16 +17,16 @@
 # NOTE: These are intended to be built using the arguments as
 # described in ../build.sh. See that script for more details.
 
-FROM balenalib/aarch64-debian:stretch-build
+FROM centos:8
 
 # Choose whether to install SpiderMonkey 1.8.5, default yes
 ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
-ARG erlangversion=19.3.6
-ARG elixirversion=v1.6.6
-ARG nodeversion=8
+ARG erlangversion=20.3.8.23
+ARG elixirversion=v1.9.1
+ARG nodeversion=10
 
 # Create Jenkins user and group
 RUN groupadd --gid 910 jenkins; \
@@ -39,6 +39,9 @@ ADD --chown=root:root files /root/couchdb-ci/files/
 # Jenkins builds in /usr/src/couchdb.
 RUN mkdir -p /usr/src/couchdb; \
   chown -R jenkins:jenkins /usr/src/couchdb
+
+# Add /usr/local/lib to global LD_LIBRARY_PATH for CentOS
+RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/local.conf
 
 # Install all dependencies, and optionally SM 1.8.5
 # This allows us to use the same Dockerfile for building SM

--- a/dockerfiles/debian-buster
+++ b/dockerfiles/debian-buster
@@ -17,15 +17,18 @@
 # NOTE: These are intended to be built using the arguments as
 # described in ../build.sh. See that script for more details.
 
-FROM debian:buster
+# Support multi-platform builds with a single Dockerfile
+ARG containerarch=amd64
+
+FROM $containerarch/debian:buster
 
 # Choose whether to install SpiderMonkey 1.8.5, default yes
 ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
-# Select version of Node, Erlang and Elixir to install
+# Select version of Node, Erlang and Elixir
 ARG erlangversion=20.3.8.22-1
-ARG elixirversion=v1.6.6
+ARG elixirversion=v1.9.1
 ARG nodeversion=10
 
 # Create Jenkins user and group

--- a/dockerfiles/debian-jessie
+++ b/dockerfiles/debian-jessie
@@ -24,9 +24,9 @@ ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
-ARG erlangversion=19.3.6
-ARG elixirversion=v1.6.6
-ARG nodeversion=8
+ARG erlangversion=20.3.8.22-1
+ARG elixirversion=v1.9.1
+ARG nodeversion=10
 
 # Create Jenkins user and group
 RUN groupadd --gid 910 jenkins; \

--- a/dockerfiles/debian-stretch
+++ b/dockerfiles/debian-stretch
@@ -17,16 +17,19 @@
 # NOTE: These are intended to be built using the arguments as
 # described in ../build.sh. See that script for more details.
 
-FROM debian:stretch
+# Support multi-platform builds with a single Dockerfile
+ARG containerarch=amd64
+
+FROM $containerarch/debian:stretch
 
 # Choose whether to install SpiderMonkey 1.8.5, default yes
 ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
-# Select version of Node, Erlang and Elixir to install
-ARG erlangversion=19.3.6
-ARG elixirversion=v1.6.6
-ARG nodeversion=8
+# Select version of Node, Erlang and Elixir
+ARG erlangversion=20.3.8.22-1
+ARG elixirversion=v1.9.1
+ARG nodeversion=10
 
 # Create Jenkins user and group
 RUN groupadd --gid 910 jenkins; \

--- a/dockerfiles/ubuntu-bionic
+++ b/dockerfiles/ubuntu-bionic
@@ -24,9 +24,9 @@ ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
-ARG erlangversion=19.3.6
-ARG elixirversion=v1.6.6
-ARG nodeversion=8
+ARG erlangversion=20.3.8.22-1
+ARG elixirversion=v1.9.1
+ARG nodeversion=10
 
 # Create Jenkins user and group
 RUN groupadd --gid 910 jenkins; \

--- a/dockerfiles/ubuntu-trusty
+++ b/dockerfiles/ubuntu-trusty
@@ -24,9 +24,9 @@ ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
-ARG erlangversion=19.3.6
-ARG elixirversion=v1.6.6
-ARG nodeversion=8
+ARG erlangversion=20.3.8.22-1
+ARG elixirversion=v1.9.1
+ARG nodeversion=10
 
 # Create Jenkins user and group
 RUN groupadd --gid 910 jenkins; \

--- a/dockerfiles/ubuntu-xenial
+++ b/dockerfiles/ubuntu-xenial
@@ -24,9 +24,9 @@ ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
-ARG erlangversion=19.3.6
-ARG elixirversion=v1.6.6
-ARG nodeversion=8
+ARG erlangversion=20.3.8.22-1
+ARG elixirversion=v1.9.1
+ARG nodeversion=10
 
 # Create Jenkins user and group
 RUN groupadd --gid 910 jenkins; \


### PR DESCRIPTION
README.md summarises most of the changes. We now use a single Dockerfile
per OS-release combination, and pass in the architecture necessary via
environment variables to build.sh.

Multiarch changes are only tested on debian for now. Local testing
has success on arm64v8 (aarch64) and ppc64le for Debian stretch.
arm64v8 works on Debian buster, but ppc64le + Debian buster seems to
segfault whenever running Python 3, and fails when invoking pip3.

If packages for the requested version of Erlang can't be found, the
installer script now falls back to building Erlang from source,
allowing any arbitrary combination to be specified. Be careful, and
watch your build output for this fallback occuring - we prefer the
Erlang Solutions packages to building from source when possible.

Finally, this includes bumps of default versions:
* Node.JS: v10
* Erlang: v20.3.8.22
* Elixir: v1.9.1

Closes #20 

CentOS 8 support has also been added in this PR, as well as RPM
support for arbitrary Erlangs.