### PR TITLE
Add epoch to override dist, ErlSolns packages (deb)

### DIFF
--- a/bin/apt-erlang.sh
+++ b/bin/apt-erlang.sh
@@ -52,7 +52,7 @@ Priority: optional
 Standards-Version: 3.9.2
 Package: $1
 Provides: $1
-Version: ${ERLANGVERSION}
+Version: 2:${ERLANGVERSION}
 Description: Fake $1 package to appease package builder
 EOF
   equivs-build $1-control


### PR DESCRIPTION
This ensures our fake local package (when falling back to source install) will always override distro and Erlang Solutions erlang packages. This, in turn, ensures an orderly and correct package build process.