### PR TITLE
Add FoundationDB support, pass 1

### DIFF
--- a/bin/apt-dependencies.sh
+++ b/bin/apt-dependencies.sh
@@ -76,7 +76,7 @@ apt-get install -y apt-transport-https curl git pkg-config \
     curl debhelper devscripts dh-exec dh-python equivs \
     dialog equivs lintian libwww-perl quilt \
     reprepro createrepo rsync \
-    vim-tiny screen \
+    vim-tiny screen procps
 
 if [[ ${VERSION_CODENAME} == "xenial" ]]; then
   apt remove -y ${VENV}
@@ -176,6 +176,13 @@ else
 fi
 
 # Erlang is installed by apt-erlang.sh
+
+# FoundationDB
+wget https://www.foundationdb.org/downloads/6.2.15/ubuntu/installers/foundationdb-clients_6.2.15-1_amd64.deb
+wget https://www.foundationdb.org/downloads/6.2.15/ubuntu/installers/foundationdb-server_6.2.15-1_amd64.deb
+dpkg -i ./foundationdb*deb
+pkill -f fdb || true
+pkill -f foundation || true
 
 # clean up
 apt-get clean

--- a/bin/pkg-dependencies.sh
+++ b/bin/pkg-dependencies.sh
@@ -56,5 +56,8 @@ else
   pkg install -y libffi autotools
 fi
 
+# FoundationDB
+pkg install -y foundationdb foundationdb-devel
+
 # Erlang is installed by pkg-erlang.sh
 

--- a/bin/yum-dependencies.sh
+++ b/bin/yum-dependencies.sh
@@ -198,5 +198,17 @@ else
   yum install -y libffi-devel
 fi
 
+# FoundationDB
+if [[ ${VERSION_ID} -eq 6 ]]; then
+  wget https://www.foundationdb.org/downloads/6.2.15/rhel6/installers/foundationdb-clients-6.2.15-1.el6.x86_64.rpm
+  wget https://www.foundationdb.org/downloads/6.2.15/rhel6/installers/foundationdb-server-6.2.15-1.el6.x86_64.rpm
+else
+  wget https://www.foundationdb.org/downloads/6.2.15/rhel7/installers/foundationdb-clients-6.2.15-1.el7.x86_64.rpm
+  wget https://www.foundationdb.org/downloads/6.2.15/rhel7/installers/foundationdb-server-6.2.15-1.el7.x86_64.rpm
+fi
+yum --nogpgcheck localinstall -y foundationdb*rpm
+pkill -f fdb || true
+pkill -f foundation || true
+
 # clean up
 yum clean all -y


### PR DESCRIPTION
This adds support for FoundationDB to our matrix.

Right now, this has been tested with the debian* and ubuntu* images, and has been pushed for the `debian-buster-erlang-all` image.

There's some gaps before we can fully support all platforms, see: https://forums.foundationdb.org/t/package-download-questions/2037/3