### PR TITLE
Update process for multi-arch images, add builder Action

### DIFF
--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -1,0 +1,63 @@
+name: Image Builder
+
+on:
+  workflow_dispatch:
+    inputs:
+      dockerfile:
+        description: 'Dockerfile'
+        required: true
+        default: 'debian-bullseye'
+      erlangVersion:
+        description: 'Erlang/OTP Version'
+        required: true
+        default: '24.2'
+      elixirVersion:
+        description: 'Elixir Version'
+        required: true
+        default: 'v1.12.3'
+      platforms:
+        description: 'Target Platforms'
+        required: true
+        default: 'linux/amd64'
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Authenticate to container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Inspect builder
+        run: |
+          echo "Name:      ${{ steps.buildx.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          file: dockerfiles/${{ github.event.inputs.dockerfile }}
+
+          push: true
+
+          platforms: ${{ github.event.inputs.platforms }}
+
+          build-args: |
+            erlangversion=${{ github.event.inputs.erlangVersion }}
+            elixirversion=${{ github.event.inputs.elixirVersion }}
+          tags: |
+            ghcr.io/apache/couchdb-ci:${{ github.event.inputs.dockerfile }}-erlang-${{ github.event.inputs.erlangVersion }}

--- a/bin/apt-dependencies.sh
+++ b/bin/apt-dependencies.sh
@@ -178,7 +178,6 @@ fi
 # Erlang is installed by apt-erlang.sh
 
 # FoundationDB - but only for amd64 right now!!!!
-# TODO: fix for ppc64le and s390x - get IBM to help build these packages maybe?
 if [ "${ARCH}" == "x86_64" ]; then
   wget https://github.com/apple/foundationdb/releases/download/6.3.23/foundationdb-clients_6.3.23-1_amd64.deb
   wget https://github.com/apple/foundationdb/releases/download/6.3.23/foundationdb-server_6.3.23-1_amd64.deb
@@ -186,26 +185,6 @@ if [ "${ARCH}" == "x86_64" ]; then
   pkill -f fdb || true
   pkill -f foundation || true
   rm -rf ./foundationdb*deb
-else
-  apt install --no-install-recommends -y cmake mono-devel ninja-build libboost-all-dev liblz4-dev dos2unix fakeroot liblz4-1
-  git clone https://github.com/apple/foundationdb/
-  cd foundationdb && git checkout 6.3.23
-  git apply /root/couchdb-ci/files/no-bintray.patch || true
-  mkdir .build && cd .build
-  if [ "${ARCH}" == "ppc64le" ]; then
-    cmake -DCMAKE_CXX_FLAGS="-DNO_WARN_X86_INTRINSICS" -G Ninja ..
-  else
-    cmake -G Ninja ..
-  fi
-  ninja -j2
-  fakeroot cpack -G DEB
-  # see https://forums.foundationdb.org/t/possible-missing-dependency-in-6-3-x-deb-package/2579
-  ln -nfs /usr/bin/update-alternatives /usr/bin/alternatives
-  mkdir -p /var/lib/foundationdb/data
-  dpkg -i packages/foundationdb-clients*deb packages/foundationdb-server*deb || true
-  apt purge -y cmake mono-devel ninja-build libboost-all-dev liblz4-dev dos2unix
-  apt autoremove -y
-  cd ../../ && rm -rf foundationdb
 fi
 
 # clean up

--- a/bin/yum-dependencies.sh
+++ b/bin/yum-dependencies.sh
@@ -192,20 +192,16 @@ else
   yum install -y libffi-devel
 fi
 
-# FoundationDB
-if [[ ${VERSION_ID} -eq 6 ]]; then
-  wget https://github.com/apple/foundationdb/releases/download/6.3.23/foundationdb-clients-6.3.23-1.el6.x86_64.rpm
-  wget https://github.com/apple/foundationdb/releases/download/6.3.23/foundationdb-server-6.3.23-1.el6.x86_64.rpm
-  yum --nogpgcheck localinstall -y foundationdb*rpm
-else
+# FoundationDB - but only for amd64 right now!!!!
+if [ "${ARCH}" == "x86_64" ]; then
   wget https://github.com/apple/foundationdb/releases/download/6.3.23/foundationdb-clients-6.3.23-1.el7.x86_64.rpm
   wget https://github.com/apple/foundationdb/releases/download/6.3.23/foundationdb-server-6.3.23-1.el7.x86_64.rpm
   # Buggy FoundationDB packages require this workaround
   rpm -i --nodeps ./foundationdb*rpm
+  pkill -f fdb || true
+  pkill -f foundation || true
+  rm -rf ./foundationdb*rpm
 fi
-pkill -f fdb || true
-pkill -f foundation || true
-rm -rf ./foundationdb*rpm
 
 # clean up
 yum clean all -y

--- a/build.sh
+++ b/build.sh
@@ -46,7 +46,6 @@ DEBIANS="debian-stretch debian-buster debian-bullseye"
 UBUNTUS="ubuntu-bionic ubuntu-focal"
 CENTOSES="centos-7 centos-8"
 ERLANGALL_BASE="debian-bullseye"
-BINTRAY_API="https://api.bintray.com"
 PASSED_BUILDARGS="$buildargs"
 
 

--- a/dockerfiles/debian-bullseye
+++ b/dockerfiles/debian-bullseye
@@ -17,10 +17,7 @@
 # NOTE: These are intended to be built using the arguments as
 # described in ../build.sh. See that script for more details.
 
-# Support multi-platform builds with a single Dockerfile
-ARG containerarch=amd64
-
-FROM $containerarch/debian:bullseye
+FROM debian:bullseye
 
 # Choose whether to install SpiderMonkey 1.8.5, default yes
 ARG js=js

--- a/dockerfiles/debian-buster
+++ b/dockerfiles/debian-buster
@@ -18,9 +18,7 @@
 # described in ../build.sh. See that script for more details.
 
 # Support multi-platform builds with a single Dockerfile
-ARG containerarch=amd64
-
-FROM $containerarch/debian:buster
+FROM debian:buster
 
 # Choose whether to install SpiderMonkey 1.8.5, default yes
 ARG js=js

--- a/dockerfiles/debian-stretch
+++ b/dockerfiles/debian-stretch
@@ -17,10 +17,7 @@
 # NOTE: These are intended to be built using the arguments as
 # described in ../build.sh. See that script for more details.
 
-# Support multi-platform builds with a single Dockerfile
-ARG containerarch=amd64
-
-FROM $containerarch/debian:stretch
+FROM debian:stretch
 
 # Choose whether to install SpiderMonkey 1.8.5, default yes
 ARG js=js


### PR DESCRIPTION
This PR documents the process to build multi-arch container images with the Docker `buildx` plugin. It also creates a GitHub Action that allows building these images directly from the GitHub UI instead of messing with the `build.sh` script.

Currently the images get posted to the GitHub Container Registry instead of Docker Hub. I did this intentionally as it seems worthwhile to evaluate using GHCR for this "internal" CouchDB use case instead of Docker Hub. But it really is just an evaluation. Happy to entertain feedback.

I am interested in the idea of setting up some event triggering so that e.g. new images get published when a new Erlang version is released and then get picked up automatically by Jenkins. For now though the Action is just a manually invoked one.