### PR TITLE
Add ubuntu jammy

### DIFF
--- a/bin/apt-dependencies.sh
+++ b/bin/apt-dependencies.sh
@@ -43,7 +43,7 @@ SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 . ${SCRIPTPATH}/detect-arch.sh >/dev/null
 . ${SCRIPTPATH}/detect-os.sh >/dev/null
 debians='(jessie|buster)'
-ubuntus='(bionic|focal)'
+ubuntus='(bionic|focal|jammy)'
 echo "Detected Ubuntu/Debian version: ${VERSION_CODENAME}   arch: ${ARCH}"
 
 # bionic Docker image seems to be missing /etc/timezone...
@@ -151,7 +151,7 @@ fi
 # js packages, as long as we're not told to skip them
 if [ "$1" != "nojs" ]; then
   # older releases don't have libmozjs60+, and we provide 1.8.5
-  if [ "${VERSION_CODENAME}" != "focal" -a "${VERSION_CODENAME}" != "bullseye" -a "${ARCH}" != "s390x" ]; then
+  if [ "${VERSION_CODENAME}" != "jammy" -a "${VERSION_CODENAME}" != "focal" -a "${VERSION_CODENAME}" != "bullseye" -a "${ARCH}" != "s390x" ]; then
     curl https://couchdb.apache.org/repo/keys.asc | gpg --dearmor | tee /usr/share/keyrings/couchdb-archive-keyring.gpg >/dev/null 2>&1
     source /etc/os-release
     echo "deb [signed-by=/usr/share/keyrings/couchdb-archive-keyring.gpg] https://apache.jfrog.io/artifactory/couchdb-deb/ ${VERSION_CODENAME} main" \
@@ -165,6 +165,9 @@ if [ "$1" != "nojs" ]; then
   fi
   if [ "${VERSION_CODENAME}" == "focal" ]; then
     apt-get install --no-install-recommends -y libmozjs-68-dev
+  fi
+  if [ "${VERSION_CODENAME}" == "jammy" ]; then
+    apt-get install --no-install-recommends -y libmozjs-78-dev libmozjs-91-dev
   fi
   if [ "${VERSION_CODENAME}" == "bullseye" ]; then
     apt-get install --no-install-recommends -y libmozjs-78-dev

--- a/build.sh
+++ b/build.sh
@@ -43,7 +43,7 @@ SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 #    https://access.redhat.com/support/policy/updates/errata/ (same for CentOS)
 #    also https://endoflife.software/operating-systems/linux/centos
 DEBIANS="debian-buster debian-bullseye"
-UBUNTUS="ubuntu-bionic ubuntu-focal"
+UBUNTUS="ubuntu-bionic ubuntu-focal ubuntu-jammy"
 CENTOSES="centos-7 rockylinux-8"
 ERLANGALL_BASE="debian-bullseye"
 XPLAT_BASE="debian-bullseye"

--- a/dockerfiles/ubuntu-jammy
+++ b/dockerfiles/ubuntu-jammy
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing,
+#   software distributed under the License is distributed on an
+#   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#   KIND, either express or implied.  See the License for the
+#   specific language governing permissions and limitations
+
+# NOTE: These are intended to be built using the arguments as
+# described in ../build.sh. See that script for more details.
+
+FROM ubuntu:jammy
+
+# Choose whether to install SpiderMonkey 1.8.5, default yes
+ARG js=js
+# Choose whether to install Erlang, default yes
+ARG erlang=erlang
+# Select version of Node, Erlang and Elixir to install
+ARG erlangversion=23.3.4.14
+ARG elixirversion=v1.12.3
+ARG nodeversion=14
+
+# Create Jenkins user and group
+RUN groupadd --gid 910 jenkins; \
+  useradd --uid 910 --gid jenkins --create-home jenkins
+
+# Copy couchdb-ci repo into root's home directory
+ADD --chown=root:root bin /root/couchdb-ci/bin/
+ADD --chown=root:root files /root/couchdb-ci/files/
+
+# Jenkins builds in /usr/src/couchdb.
+RUN mkdir -p /usr/src/couchdb; \
+  chown -R jenkins:jenkins /usr/src/couchdb
+
+# Install all dependencies, and optionally SM 1.8.5
+# This allows us to use the same Dockerfile for building SM
+RUN ERLANGVERSION=$erlangversion \
+  ELIXIRVERSION=$elixirversion \
+  NODEVERSION=$nodeversion \
+  /root/couchdb-ci/bin/install-dependencies.sh $js $erlang
+
+# Allow Jenkins to sudo
+RUN echo "jenkins ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/jenkins
+
+USER jenkins
+
+# overwrite this with 'CMD []' in a dependent Dockerfile
+CMD ["/bin/bash"]


### PR DESCRIPTION
Noticed issues with both the qemu emulator for ARM (illegal instruction) and with building Erlang from source (openssl 3.0
compatibility) so opted to use the default erlang 24 from jammy and build for amd64 architecture only for the pushed image:

```
ERLANGVERSION=default ./build.sh buildx-platform ubuntu-jammy
```

To check out the image:
```
docker pull apache/couchdbci-ubuntu:jammy-erlang-default
```