### PR TITLE
Build Erlang 25+ without jit for arm64

### DIFF
--- a/bin/source-erlang.sh
+++ b/bin/source-erlang.sh
@@ -63,12 +63,24 @@ git clone https://github.com/erlang/otp.git
 cd otp
 git checkout OTP-${ERLANGVERSION} -b local-OTP-${ERLANGVERSION}
 
+ERLANGMAJORVERSION=`echo $ERLANGVERSION | cut -d. -f 1`
+if [[ ${ERLANGMAJORVERSION} -ge 25 ]] && [[ ${ARCH} == "aarch64" ]]; then
+    echo "*************************  WARNING ***************************"
+    echo "Currently, as of 2022-07-02, Erlang 25.0.2 segfaults building"
+    echo "the linux/arm64 image on linux/amd64 in QEMU. Because"
+    echo "of that we disable JIT for arm64."
+    echo "**************************************************************"
+    DISABLE_JIT="--disable-jit"
+else
+    DISABLE_JIT=""
+fi
+
 # Configure Erlang - skip building things we don't want or need
 ./configure --without-javac --without-wx --without-odbc \
   --without-debugger --without-observer --without-et  --without-cosEvent \
   --without-cosEventDomain --without-cosFileTransfer \
   --without-cosNotification --without-cosProperty --without-cosTime \
-  --without-cosTransactions --without-orber
+  --without-cosTransactions --without-orber ${DISABLE_JIT}
 
 make -j $(nproc)
 make install

--- a/build.sh
+++ b/build.sh
@@ -51,15 +51,6 @@ XPLAT_ARCHES="arm64v8 ppc64le"
 PASSED_BUILDARGS="$buildargs"
 
 BUILDX_PLATFORMS="linux/amd64,linux/arm64,linux/ppc64le"
-ERLANGMAJORVERSION=`echo $ERLANGVERSION | cut -d. -f 1`
-if [[ ${ERLANGMAJORVERSION} -ge 25 ]]; then
-    echo "*************************  WARNING ***************************"
-    echo "Currently, as of 2022-07-02, Erlang 25.0.2 segfaults building"
-    echo "the linux/arm64 image on linux/amd64 in QEMU. Because"
-    echo "of that, build only the linux/amd64 image."
-    echo "**************************************************************"
-    BUILDX_PLATFORMS="linux/amd64"
-fi
 
 check-envs() {
   buildargs=$PASSED_BUILDARGS


### PR DESCRIPTION
Previously we completely skipped building it and also skipped ppc64le. Instead, let's build for that architecture, just without the jit for now.

Last attempt was yesterday with the latest qemu and 25.0.4 and it's still failing:

https://github.com/apache/couchdb-ci/actions/runs/3093428474/jobs/5005782105