### PR TITLE
Allow overriding buildx platforms on the command line

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -50,7 +50,10 @@ XPLAT_BASE="debian-bullseye"
 XPLAT_ARCHES="arm64v8 ppc64le"
 PASSED_BUILDARGS="$buildargs"
 
-BUILDX_PLATFORMS="linux/amd64,linux/arm64,linux/ppc64le"
+#  Allow overriding this list from the command line
+#  BUILDX_PLATFORMS=foo,bar ./build.sh ...
+#
+: "${BUILDX_PLATFORMS:=linux/amd64,linux/arm64,linux/ppc64le}"
 
 check-envs() {
   buildargs=$PASSED_BUILDARGS


### PR DESCRIPTION
Previously had to edit the build.sh file but now can pass the list of platforms on the command line as:

```
BUILDX_PLATFORMS=... ./build.sh ...
```

The syntax is a bash-only thing probably but we're explicitly using bash so that's acceptable.