### PR TITLE
Update default Erlang and cleanup unused commands

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -30,7 +30,7 @@ set -e
 
 # Defaults updated 2019-10-14
 NODEVERSION=${NODEVERSION:-14}
-ERLANGVERSION=${ERLANGVERSION:-23.3.4.15}
+ERLANGVERSION=${ERLANGVERSION:-24.3.4.7}
 ELIXIRVERSION=${ELIXIRVERSION:-v1.13.4}
 
 
@@ -96,18 +96,6 @@ case "${OSTYPE}" in
       fi
       run_scripts ${EXTRA_SCRIPTS_DIR} 'yum-'
     elif [[ ${ID} =~ ${debians} ]]; then
-
-      # Catching this early, so as to avoid user frustration
-      if [[ ${ERLANGVERSION%%.*} -le 19 ]] && [[ ${VERSION_CODENAME} =~ ${latest} ]]; then
-        if [[ $ARCH =~ $arms ]] && [[ ! ${SKIPERLANG} ]]; then
-          echo ""
-          echo "Recent versions of Linux (Stretch, Bionic, etc) provide a version of libssl"
-          echo "which is too new to complile earlier (<=19) versions of Erlang.  Please"
-          echo "either choose an earlier distro release or a more rencent version of Erlang."
-          echo ""
-          exit 1
-        fi
-      fi
 
       NODEVERSION=${NODEVERSION} ERLANGVERSION=${ERLANGVERSION} \
           ${SCRIPTPATH}/apt-dependencies.sh ${JSINSTALL}


### PR DESCRIPTION
Some of those haven't worked in more than 2 years and we've only used buildx to build both the x86 and the multi-arch images.

Ideally we wouldn't want to use proprietary Docker bits but that's the only one that works well with multi-arch builds. Perhaps Podman or other newer things can replace it soon enough.

These commands, for instance, were used to build the latest release and CI images:

```
ERLANGVERSION=24.3.4.7 ./build.sh buildx-platform-release
BUILDX_PLATFORMS=linux/amd64 ERLANGVERSION=23.3.4.18 ./build.sh buildx-platform debian-bullseye
ERLANGVERSION=24.3.4.7 ./build.sh buildx-platform debian-bullseye
BUILDX_PLATFORMS=linux/amd64 ERLANGVERSION=25.2 ./build.sh buildx-platform debian-bullseye
```