### PR TITLE
Update pull-all-couchdbdev-docker script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,6 +42,10 @@ SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 #    https://ubuntu.com/about/release-cycle
 #    https://access.redhat.com/support/policy/updates/errata/ (same for CentOS)
 #    also https://endoflife.software/operating-systems/linux/centos
+
+# When updating the images, consider updating pull-all-couchdbdev-docker
+# script as well
+#
 DEBIANS="debian-buster debian-bullseye"
 UBUNTUS="ubuntu-bionic ubuntu-focal ubuntu-jammy"
 CENTOSES="centos-7 rockylinux-8"

--- a/pull-all-couchdbdev-docker
+++ b/pull-all-couchdbdev-docker
@@ -4,46 +4,22 @@ DOCKER_ORG="apache"
 
 # These are the images that are currently being used, so don't `docker rmi` them on cleanup.
 KEEP_IMAGES=(
-couchdbci-debian:buster-erlang-20.3.8.26-1
-couchdbci-debian:arm64v8-buster-erlang-20.3.8.26-1
-couchdbci-debian:buster-erlang-all
-couchdbci-centos:8-erlang-20.3.8.26-1
-couchdbci-centos:7-erlang-20.3.8.26-1
-couchdbci-ubuntu:focal-erlang-20.3.8.26-1
-couchdbci-ubuntu:bionic-erlang-20.3.8.26-1
-couchdbci-debian:erlang-20
-couchdbci-debian:erlang-21
-couchdbci-debian:erlang-22
-couchdbci-debian:erlang-23
-couchdbci-debian:erlang-24
-couchdbci-debian:buster-erlang-24.2
-couchdbci-debian:bullseye-erlang-24.2
-couchdbci-centos:8-erlang-24.2
-couchdbci-centos:7-erlang-24.2
-couchdbci-ubuntu:focal-erlang-24.2
-couchdbci-ubuntu:bionic-erlang-24.2
+couchdbci-debian:bullseye-erlang-23.3.4.17
+couchdbci-debian:buster-erlang-23.3.4.17
+couchdbci-debian:bullseye-erlang-25.2
+couchdbci-debian:bullseye-erlang-23.3.4.18
+couchdbci-debian:buster-erlang-24.3.4.7	14
+couchdbci-debian:bullseye-erlang-24.3.4.7
+couchdbci-centos:8-erlang-24.3.4.7
+couchdbci-centos:7-erlang-24.3.4.7
+couchdbci-ubuntu:bionic-erlang-23.3.4.17
+couchdbci-ubuntu:focal-erlang-23.3.4.17
+couchdbci-ubuntu:bionic-erlang-24.3.4.7
+couchdbci-ubuntu:jammy-erlang-24.3.4.7
+couchdbci-ubuntu:focal-erlang-24.3.4.7
 )
 
-# Base images are used for building old libmozjs, primarily.
-BASE_IMAGES=(
-couchdbci-debian:ppc64le-buster-base
-)
-# These images layer in the rest of the CouchDB build chain, and 1 or more Erlang versions.
-IMAGES=(
-couchdbci-debian:arm64v8-buster-erlang-20.3.8.25-1
-couchdbci-debian:ppc64le-buster-erlang-20.3.8.25-1
-couchdbci-centos:6-erlang-20.3.8.25-1
-couchdbci-centos:6-erlang-19.3.6
-couchdbci-centos:7-erlang-19.3.6
-)
-
-if [ "$(date +%u)" -ne "1" ]; then
-    LIST=( ${KEEP_IMAGES[*]})
-else
-    LIST=( ${IMAGES[*]} ${BASE_IMAGES[*]} )
-fi
-
-for image in ${LIST[*]}
+for image in ${KEEP_IMAGES[*]}
 do
     echo docker pull ${DOCKER_ORG}/${image}
     docker pull ${DOCKER_ORG}/${image}


### PR DESCRIPTION
It turns out were were pruning all the active images as we a bunch of stale Erlang 19 and 20 ones in the list to keep. Update the list so it's current and add a note to the list OS image variables as a reminder to keep the cleanup script in sync.

This should hopefully save 2-3 minutes on each CI run as the most of the docker images should already be there. Previously it took about that much it looks like to fetch the images on every CI run after the prune script ran.