### PR TITLE
Add --enable-fips Erlang configure option

### DIFF
--- a/bin/source-erlang.sh
+++ b/bin/source-erlang.sh
@@ -80,7 +80,7 @@ fi
   --without-debugger --without-observer --without-et  --without-cosEvent \
   --without-cosEventDomain --without-cosFileTransfer \
   --without-cosNotification --without-cosProperty --without-cosTime \
-  --without-cosTransactions --without-orber ${DISABLE_JIT}
+  --without-cosTransactions --without-orber --enable-fips ${DISABLE_JIT}
 
 make -j $(nproc)
 make install


### PR DESCRIPTION
By itself this doesn't enable FIPS mode, just allows users to toggle Erlang's FIPS mode if their crypto library happens to support it.

After this `crypto:info_fips().` sould start returning `not_enabled` as opposed `not_supported` is it does currently.

https://www.erlang.org/docs/23/apps/crypto/fips.html