### PR TITLE
Refresh docker pull images

### DIFF
--- a/pull-all-couchdbdev-docker
+++ b/pull-all-couchdbdev-docker
@@ -5,17 +5,13 @@ DOCKER_ORG="apache"
 # These are the images that are currently being used, so don't `docker rmi` them on cleanup.
 KEEP_IMAGES=(
 couchdbci-debian:bullseye-erlang-25.3
-couchdbci-debian:bullseye-erlang-24.3.4.10
-couchdbci-debian:bullseye-erlang-23.3.4.18
 couchdbci-debian:buster-erlang-24.3.4.10
-couchdbci-debian:buster-erlang-23.3.4.18
+couchdbci-debian:bullseye-erlang-24.3.4.10
 couchdbci-centos:8-erlang-24.3.4.10
 couchdbci-centos:7-erlang-24.3.4.10
+couchdbci-ubuntu:bionic-erlang-24.3.4.10
 couchdbci-ubuntu:jammy-erlang-24.3.4.10
 couchdbci-ubuntu:focal-erlang-24.3.4.10
-couchdbci-ubuntu:focal-erlang-23.3.4.18
-couchdbci-ubuntu:bionic-erlang-24.3.4.10
-couchdbci-ubuntu:bionic-erlang-23.3.4.18
 )
 
 for image in ${KEEP_IMAGES[*]}


### PR DESCRIPTION
We updated the image but forgot to update this list

So we kept removing the new images and pulling them too often, thus hitting rate limits from dockerhub.