### PR TITLE
Add s390x support for RHEL8 clone CI image

### DIFF
--- a/bin/detect-os.sh
+++ b/bin/detect-os.sh
@@ -68,7 +68,7 @@ case "${OSTYPE}" in
     # and finally some rough heuristics
     if [[ -f /etc/redhat-release ]]; then
       # /etc/redhat-release is so inconsistent, we use rpm instead
-      rhelish=$(rpm -qa '(redhat|sl|slf|centos|centos-linux|oraclelinux|rocky)-release(|-server|-workstation|-client|-computenode)' 2>/dev/null | head -1)
+      rhelish=$(rpm -qa '(redhat|sl|slf|centos|centos-linux|oraclelinux|almalinux)-release(|-server|-workstation|-client|-computenode)' 2>/dev/null | head -1)
       if [[ $rhelish ]]; then
         ID=${ID:-$(echo ${rhelish} | awk -F'-' '{print tolower($1)}')}
         VERSION_ID=${VERSION_ID:-$(echo ${rhelish} | sed -E 's/([^[:digit:]]+)([[:digit:]]+)(.*)/\2/' )}

--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -83,7 +83,7 @@ arms='(aarch64)'
 
 case "${OSTYPE}" in
   linux*)
-    redhats='(rhel|centos|fedora|rocky)'
+    redhats='(rhel|centos|fedora|almalinux)'
     debians='(debian|ubuntu)'
     latest='(stretch|buster|bionic)'
 

--- a/bin/source-erlang.sh
+++ b/bin/source-erlang.sh
@@ -38,7 +38,7 @@ SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 . ${SCRIPTPATH}/detect-os.sh
 
-redhats='(rhel|centos|fedora|rocky)'
+redhats='(rhel|centos|fedora|almalinux)'
 debians='(debian|ubuntu)'
 
 echo "Erlang source build started @ $(date)"

--- a/bin/yum-dependencies.sh
+++ b/bin/yum-dependencies.sh
@@ -86,7 +86,7 @@ echo "Detected RedHat/Centos/Fedora version: ${VERSION_ID}   arch: ${ARCH}"
 
 # Enable EPEL
 yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-${VERSION_ID}.noarch.rpm || true
-# PowerTools for Rocky 8
+# PowerTools for Alma 8
 if [[ ${VERSION_ID} -eq 8 ]]; then
   dnf install -y 'dnf-command(config-manager)'
   dnf config-manager --set-enabled powertools

--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,7 @@ SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 #
 DEBIANS="debian-buster debian-bullseye"
 UBUNTUS="ubuntu-bionic ubuntu-focal ubuntu-jammy"
-CENTOSES="centos-7 rockylinux-8 rockylinux-9"
+CENTOSES="centos-7 almalinux-8 almalinux-9"
 XPLAT_BASE="debian-bullseye"
 XPLAT_ARCHES="arm64v8 ppc64le s390x"
 PASSED_BUILDARGS="$buildargs"
@@ -104,7 +104,7 @@ buildx-platform() {
   find-erlang-version $1
   pull-os-image $1
   split-os-ver $1
-  if [ "$os" == "rockylinux" ]; then
+  if [ "$os" == "almalinux" ]; then
     repo="centos"
   else
     repo="$os"

--- a/dockerfiles/almalinux-8
+++ b/dockerfiles/almalinux-8
@@ -17,7 +17,7 @@
 # NOTE: These are intended to be built using the arguments as
 # described in ../build.sh. See that script for more details.
 
-FROM rockylinux:9
+FROM almalinux:8
 
 # Install Java
 ENV JAVA_HOME=/opt/java/openjdk

--- a/dockerfiles/almalinux-9
+++ b/dockerfiles/almalinux-9
@@ -17,7 +17,7 @@
 # NOTE: These are intended to be built using the arguments as
 # described in ../build.sh. See that script for more details.
 
-FROM rockylinux:8
+FROM almalinux:9
 
 # Install Java
 ENV JAVA_HOME=/opt/java/openjdk


### PR DESCRIPTION
The current RHEL8 clone CI image `apache/couchdbci-centos:8-erlang-24.3.4.10` doesn't support s390x since it's based on `rockylinux:8` which doesn't have s390x support yet. 

This PR aims to replace the base image `rockylinux:8` with `almalinux-8`, so that s390x support could be added to RHEL8 clone CI image, and features on other arches won't be affected.