### PR TITLE
Handle Debian 12 Bookworm

### DIFF
--- a/bin/apt-dependencies.sh
+++ b/bin/apt-dependencies.sh
@@ -75,10 +75,10 @@ apt-get install --no-install-recommends -y apt-transport-https curl git pkg-conf
 
 
 # createrepo_c or createrepo, depending on packaging support
-if [ ${VERSION_CODENAME} == "bullseye" ]; then
+if [ ${VERSION_CODENAME} == "bullseye" -o ${VERSION_CODENAME} == "bookworm" ]; then
   apt-get install --no-install-recommends -y createrepo-c || true
 else
-  # python 2 based; gone from focal / bullseye. look for createrepo_c eventually
+  # python 2 based; gone from focal / bullseye / bookworm. look for createrepo_c eventually
   # hopefully via: https://github.com/rpm-software-management/createrepo_c/issues/145
   apt-get install --no-install-recommends -y createrepo || true
 fi
@@ -146,7 +146,7 @@ fi
 # js packages, as long as we're not told to skip them
 if [ "$1" != "nojs" ]; then
   # older releases don't have libmozjs60+, and we provide 1.8.5
-  if [ "${VERSION_CODENAME}" != "jammy" -a "${VERSION_CODENAME}" != "focal" -a "${VERSION_CODENAME}" != "bullseye" -a "${ARCH}" != "s390x" ]; then
+  if [ "${VERSION_CODENAME}" != "jammy" -a "${VERSION_CODENAME}" != "focal" -a "${VERSION_CODENAME}" != "bullseye" -a "${VERSION_CODENAME}" != "bookworm" -a "${ARCH}" != "s390x" ]; then
     curl https://couchdb.apache.org/repo/keys.asc | gpg --dearmor | tee /usr/share/keyrings/couchdb-archive-keyring.gpg >/dev/null 2>&1
     source /etc/os-release
     echo "deb [signed-by=/usr/share/keyrings/couchdb-archive-keyring.gpg] https://apache.jfrog.io/artifactory/couchdb-deb/ ${VERSION_CODENAME} main" \
@@ -164,7 +164,7 @@ if [ "$1" != "nojs" ]; then
   if [ "${VERSION_CODENAME}" == "jammy" ]; then
     apt-get install --no-install-recommends -y libmozjs-78-dev libmozjs-91-dev
   fi
-  if [ "${VERSION_CODENAME}" == "bullseye" ]; then
+  if [ "${VERSION_CODENAME}" == "bullseye" ] || [ "${VERSION_CODENAME}" == "bookworm" ]; then
     apt-get install --no-install-recommends -y libmozjs-78-dev
   fi
 else

--- a/build.sh
+++ b/build.sh
@@ -46,10 +46,10 @@ SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # When updating the images, consider updating pull-all-couchdbdev-docker
 # script as well
 #
-DEBIANS="debian-buster debian-bullseye"
+DEBIANS="debian-buster debian-bullseye debian-bookworm"
 UBUNTUS="ubuntu-bionic ubuntu-focal ubuntu-jammy"
 CENTOSES="centos-7 almalinux-8 almalinux-9"
-XPLAT_BASE="debian-bullseye"
+XPLAT_BASES="debian-bullseye debian-bookworm"
 XPLAT_ARCHES="arm64v8 ppc64le s390x"
 PASSED_BUILDARGS="$buildargs"
 

--- a/dockerfiles/debian-bookworm
+++ b/dockerfiles/debian-bookworm
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing,
+#   software distributed under the License is distributed on an
+#   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#   KIND, either express or implied.  See the License for the
+#   specific language governing permissions and limitations
+
+# NOTE: These are intended to be built using the arguments as
+# described in ../build.sh. See that script for more details.
+
+ARG repository=debian
+
+FROM $repository:bookworm
+
+# Install Java
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+# Choose whether to install SpiderMonkey 1.8.5, default yes
+ARG js=js
+# Choose whether to install Erlang, default yes
+ARG erlang=erlang
+# Select version of Node, Erlang and Elixir
+ARG erlangversion=24.3.4.10
+ARG elixirversion=v1.14.5
+ARG nodeversion=14
+
+# Create Jenkins user and group
+RUN groupadd --gid 910 jenkins; \
+  useradd --uid 910 --gid jenkins --create-home jenkins
+
+# Copy couchdb-ci repo into root's home directory
+ADD --chown=root:root bin /root/couchdb-ci/bin/
+ADD --chown=root:root files /root/couchdb-ci/files/
+
+# Jenkins builds in /usr/src/couchdb.
+RUN mkdir -p /usr/src/couchdb; \
+  chown -R jenkins:jenkins /usr/src/couchdb
+
+# Install all dependencies, and optionally SM 1.8.5
+# This allows us to use the same Dockerfile for building SM
+RUN ERLANGVERSION=$erlangversion \
+  ELIXIRVERSION=$elixirversion \
+  NODEVERSION=$nodeversion \
+  /root/couchdb-ci/bin/install-dependencies.sh $js $erlang
+
+# Allow Jenkins to sudo
+RUN echo "jenkins ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/jenkins
+
+USER jenkins
+
+# overwrite this with 'CMD []' in a dependent Dockerfile
+CMD ["/bin/bash"]

--- a/pull-all-couchdbdev-docker
+++ b/pull-all-couchdbdev-docker
@@ -5,8 +5,10 @@ DOCKER_ORG="apache"
 # These are the images that are currently being used, so don't `docker rmi` them on cleanup.
 KEEP_IMAGES=(
 couchdbci-debian:bullseye-erlang-25.3
+couchdbci-debian:bookworm-erlang-25.3
 couchdbci-debian:buster-erlang-24.3.4.10
 couchdbci-debian:bullseye-erlang-24.3.4.10
+couchdbci-debian:bookworm-erlang-24.3.4.10
 couchdbci-centos:9-erlang-24.3.4.10
 couchdbci-centos:8-erlang-24.3.4.10
 couchdbci-centos:7-erlang-24.3.4.10


### PR DESCRIPTION
Add necessary bits to package for Debian 12 Bookworm.

Someone with access to CI will neet to take a look at that. This PR has been made blindly with no visibility on repositories and CI.

This adresses https://github.com/apache/couchdb-pkg/issues/112