### PR TITLE
feat: add Java 8 to the Docker images for running Clouseau

### DIFF
--- a/dockerfiles/almalinux-8
+++ b/dockerfiles/almalinux-8
@@ -24,6 +24,11 @@ ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
+# These are needed for the Clouseau integration
+ENV CLOUSEAU_JAVA_HOME=/opt/java/openjdk8
+COPY --from=ibm-semeru-runtimes:open-8-jre /opt/java/openjdk $CLOUSEAU_JAVA_HOME
+ENV PATH=/usr/local/lib/erlang/bin:"${PATH}"
+
 # Choose whether to install SpiderMonkey 1.8.5, default yes
 ARG js=js
 # Choose whether to install Erlang, default yes

--- a/dockerfiles/almalinux-9
+++ b/dockerfiles/almalinux-9
@@ -24,6 +24,11 @@ ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
+# These are needed for the Clouseau integration
+ENV CLOUSEAU_JAVA_HOME=/opt/java/openjdk8
+COPY --from=ibm-semeru-runtimes:open-8-jre /opt/java/openjdk $CLOUSEAU_JAVA_HOME
+ENV PATH=/usr/local/lib/erlang/bin:"${PATH}"
+
 # Choose whether to install SpiderMonkey 1.8.5, default yes
 ARG js=js
 # Choose whether to install Erlang, default yes

--- a/dockerfiles/centos-7
+++ b/dockerfiles/centos-7
@@ -24,6 +24,11 @@ ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
+# These are needed for the Clouseau integration
+ENV CLOUSEAU_JAVA_HOME=/opt/java/openjdk8
+COPY --from=ibm-semeru-runtimes:open-8-jre /opt/java/openjdk $CLOUSEAU_JAVA_HOME
+ENV PATH=/usr/local/lib/erlang/bin:"${PATH}"
+
 # Choose whether to install SpiderMonkey 1.8.5, default yes
 ARG js=js
 # Choose whether to install Erlang, default yes

--- a/dockerfiles/debian-bookworm
+++ b/dockerfiles/debian-bookworm
@@ -26,6 +26,11 @@ ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
+# These are needed for the Clouseau integration
+ENV CLOUSEAU_JAVA_HOME=/opt/java/openjdk8
+COPY --from=ibm-semeru-runtimes:open-8-jre /opt/java/openjdk $CLOUSEAU_JAVA_HOME
+ENV PATH=/usr/local/lib/erlang/bin:"${PATH}"
+
 # Choose whether to install SpiderMonkey 1.8.5, default yes
 ARG js=js
 # Choose whether to install Erlang, default yes

--- a/dockerfiles/debian-bullseye
+++ b/dockerfiles/debian-bullseye
@@ -26,6 +26,11 @@ ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
+# These are needed for the Clouseau integration
+ENV CLOUSEAU_JAVA_HOME=/opt/java/openjdk8
+COPY --from=ibm-semeru-runtimes:open-8-jre /opt/java/openjdk $CLOUSEAU_JAVA_HOME
+ENV PATH=/usr/local/lib/erlang/bin:"${PATH}"
+
 # Choose whether to install SpiderMonkey 1.8.5, default yes
 ARG js=js
 # Choose whether to install Erlang, default yes

--- a/dockerfiles/debian-buster
+++ b/dockerfiles/debian-buster
@@ -26,6 +26,11 @@ ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
+# These are needed for the Clouseau integration
+ENV CLOUSEAU_JAVA_HOME=/opt/java/openjdk8
+COPY --from=ibm-semeru-runtimes:open-8-jre /opt/java/openjdk $CLOUSEAU_JAVA_HOME
+ENV PATH=/usr/local/lib/erlang/bin:"${PATH}"
+
 # Choose whether to install SpiderMonkey 1.8.5, default yes
 ARG js=js
 # Choose whether to install Erlang, default yes

--- a/dockerfiles/ubuntu-bionic
+++ b/dockerfiles/ubuntu-bionic
@@ -24,6 +24,11 @@ ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
+# These are needed for the Clouseau integration
+ENV CLOUSEAU_JAVA_HOME=/opt/java/openjdk8
+COPY --from=ibm-semeru-runtimes:open-8-jre /opt/java/openjdk $CLOUSEAU_JAVA_HOME
+ENV PATH=/usr/local/lib/erlang/bin:"${PATH}"
+
 # Choose whether to install SpiderMonkey 1.8.5, default yes
 ARG js=js
 # Choose whether to install Erlang, default yes

--- a/dockerfiles/ubuntu-focal
+++ b/dockerfiles/ubuntu-focal
@@ -24,6 +24,11 @@ ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
+# These are needed for the Clouseau integration
+ENV CLOUSEAU_JAVA_HOME=/opt/java/openjdk8
+COPY --from=ibm-semeru-runtimes:open-8-jre /opt/java/openjdk $CLOUSEAU_JAVA_HOME
+ENV PATH=/usr/local/lib/erlang/bin:"${PATH}"
+
 # Choose whether to install SpiderMonkey 1.8.5, default yes
 ARG js=js
 # Choose whether to install Erlang, default yes

--- a/dockerfiles/ubuntu-jammy
+++ b/dockerfiles/ubuntu-jammy
@@ -24,6 +24,11 @@ ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
+# These are needed for the Clouseau integration
+ENV CLOUSEAU_JAVA_HOME=/opt/java/openjdk8
+COPY --from=ibm-semeru-runtimes:open-8-jre /opt/java/openjdk $CLOUSEAU_JAVA_HOME
+ENV PATH=/usr/local/lib/erlang/bin:"${PATH}"
+
 # Choose whether to install SpiderMonkey 1.8.5, default yes
 ARG js=js
 # Choose whether to install Erlang, default yes


### PR DESCRIPTION
This change makes it possible to run tests that require the Search functionality to be configured.  Therefore the test coverage could be increased and issues could be caught with the related applications, such as Dreyfus and the `text` searches in Mango.