### PR TITLE
Update node, elixir and improve building

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ On the other hand, some OSes won't run older Erlangs because of library changes,
 Just specify on the command line any of the `ERLANGVERSION`, `NODEVERSION`, or `ELIXIRVERSION` environment variables:
 
 ```
-NODEVERSION=14 ELIXIRVERSION=v1.14.5 ERLANGVERSION=24.3.4.7 ./build.sh platform debian-jessie
+NODEVERSION=18 ELIXIRVERSION=v1.15.7 ERLANGVERSION=24.3.4.7 ./build.sh platform debian-bullseye
 ```
 
 ## Building images for other architectures

--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -31,7 +31,7 @@ set -e
 # Defaults updated 2023-03-20
 NODEVERSION=${NODEVERSION:-14}
 ERLANGVERSION=${ERLANGVERSION:-24.3.4.14}
-ELIXIRVERSION=${ELIXIRVERSION:-v1.14.5}
+ELIXIRVERSION=${ELIXIRVERSION:-v1.15.7}
 
 
 # This works if we're not called through a symlink

--- a/bin/install-elixir.sh
+++ b/bin/install-elixir.sh
@@ -28,7 +28,7 @@
 set -e
 
 
-ELIXIR_VSN=${ELIXIRVERSION:-v1.14.5}
+ELIXIR_VSN=${ELIXIRVERSION:-v1.15.7}
 ERLANG_VSN=`erl -noshell -eval 'io:fwrite(erlang:system_info(otp_release)), halt().'`
 # See https://github.com/hexpm/bob
 URL=https://repo.hex.pm/builds/elixir/${ELIXIR_VSN}-otp-${ERLANG_VSN}.zip

--- a/build.sh
+++ b/build.sh
@@ -49,6 +49,7 @@ SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DEBIANS="debian-buster debian-bullseye debian-bookworm"
 UBUNTUS="ubuntu-bionic ubuntu-focal ubuntu-jammy"
 CENTOSES="centos-7 almalinux-8 almalinux-9"
+
 XPLAT_BASE="debian-bullseye"
 XPLAT_ARCHES="arm64v8 ppc64le s390x"
 PASSED_BUILDARGS="$buildargs"
@@ -158,7 +159,14 @@ case "$1" in
     # For all platforms
     shift
     for plat in $DEBIANS $UBUNTUS $CENTOSES; do
-      BUILDX_PLATFORMS=linux/amd64 buildx-platform $plat
+      # Some platforms only get x86_64 builds
+      if [ "${plat}" == "debian-buster" ] || \
+         [ "${plat}" == "ubuntu-bionic" ] || \
+         [ "${plat}" == "centos-7" ]; then
+           BUILDX_PLATFORMS=linux/amd64 buildx-platform $plat
+       else
+           buildx-platform $plat
+       fi
     done
     ;;
   couch)

--- a/dockerfiles/almalinux-8
+++ b/dockerfiles/almalinux-8
@@ -30,8 +30,8 @@ ARG js=js
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
 ARG erlangversion=24.3.4.14
-ARG elixirversion=v1.14.5
-ARG nodeversion=14
+ARG elixirversion=v1.15.7
+ARG nodeversion=18
 
 # Create Jenkins user and group
 RUN groupadd --gid 910 jenkins; \

--- a/dockerfiles/almalinux-9
+++ b/dockerfiles/almalinux-9
@@ -30,8 +30,8 @@ ARG js=js
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
 ARG erlangversion=24.3.4.14
-ARG elixirversion=v1.14.5
-ARG nodeversion=14
+ARG elixirversion=v1.15.7
+ARG nodeversion=18
 
 # Create Jenkins user and group
 RUN groupadd --gid 910 jenkins; \

--- a/dockerfiles/centos-7
+++ b/dockerfiles/centos-7
@@ -30,7 +30,7 @@ ARG js=js
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
 ARG erlangversion=24.3.4.14
-ARG elixirversion=v1.14.5
+ARG elixirversion=v1.15.7
 ARG nodeversion=14
 
 # Create Jenkins user and group

--- a/dockerfiles/debian-bookworm
+++ b/dockerfiles/debian-bookworm
@@ -33,7 +33,7 @@ ARG erlang=erlang
 # Select version of Node, Erlang and Elixir
 ARG erlangversion=24.3.4.14
 ARG elixirversion=v1.15.7
-ARG nodeversion=14
+ARG nodeversion=18
 
 # Create Jenkins user and group
 RUN groupadd --gid 910 jenkins; \

--- a/dockerfiles/debian-bullseye
+++ b/dockerfiles/debian-bullseye
@@ -32,8 +32,8 @@ ARG js=js
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir
 ARG erlangversion=24.3.4.14
-ARG elixirversion=v1.14.5
-ARG nodeversion=14
+ARG elixirversion=v1.15.7
+ARG nodeversion=18
 
 # Create Jenkins user and group
 RUN groupadd --gid 910 jenkins; \

--- a/dockerfiles/debian-buster
+++ b/dockerfiles/debian-buster
@@ -32,8 +32,8 @@ ARG js=js
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir
 ARG erlangversion=24.3.4.14
-ARG elixirversion=v1.14.5
-ARG nodeversion=14
+ARG elixirversion=v1.15.7
+ARG nodeversion=18
 
 # Create Jenkins user and group
 RUN groupadd --gid 910 jenkins; \

--- a/dockerfiles/ubuntu-bionic
+++ b/dockerfiles/ubuntu-bionic
@@ -30,8 +30,8 @@ ARG js=js
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
 ARG erlangversion=24.3.4.14
-ARG elixirversion=v1.14.5
-ARG nodeversion=14
+ARG elixirversion=v1.15.7
+ARG nodeversion=16
 
 # Create Jenkins user and group
 RUN groupadd --gid 910 jenkins; \

--- a/dockerfiles/ubuntu-focal
+++ b/dockerfiles/ubuntu-focal
@@ -30,8 +30,8 @@ ARG js=js
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
 ARG erlangversion=24.3.4.14
-ARG elixirversion=v1.14.5
-ARG nodeversion=14
+ARG elixirversion=v1.15.7
+ARG nodeversion=18
 
 # Create Jenkins user and group
 RUN groupadd --gid 910 jenkins; \

--- a/dockerfiles/ubuntu-jammy
+++ b/dockerfiles/ubuntu-jammy
@@ -30,8 +30,8 @@ ARG js=js
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
 ARG erlangversion=24.3.4.14
-ARG elixirversion=v1.14.5
-ARG nodeversion=14
+ARG elixirversion=v1.15.7
+ARG nodeversion=18
 
 # Create Jenkins user and group
 RUN groupadd --gid 910 jenkins; \


### PR DESCRIPTION
 * Most node versions are now at 18, except a few which needed to be held back.

 * Elixir is at 1.15

 * Building is now a single command per erlang version:

```sh
ERLANGVERSION=24.3.4.14 ./build.sh buildx-platform-release
```