### PR TITLE
Install packaged java 21 for rpm distros

### DIFF
--- a/bin/yum-dependencies.sh
+++ b/bin/yum-dependencies.sh
@@ -112,7 +112,7 @@ yum groupinstall -y 'Development Tools'
 # help2man is for docs
 yum install -y sudo git wget which autoconf autoconf-archive automake curl-devel libicu-devel \
     libtool ncurses-devel nspr-devel zip readline-devel unzip perl \
-    createrepo xfsprogs-devel rpmdevtools
+    createrepo xfsprogs-devel java-21-openjdk-devel rpmdevtools
 if [[ ${VERSION_ID} -eq 9 ]]; then
   dnf --enablerepo=crb install -y help2man
 else
@@ -180,6 +180,10 @@ else
   # we can't add the CouchDB repo here because the plat may not exist yet
   yum install -y libffi-devel
 fi
+
+# remove openjdk8 and jna, java 21 is installed and should be the default
+# and clouseau installs it's own JRE 8 in /opt via a docker layer
+yum remove -y java-1.8.0-openjdk-headless jna
 
 # clean up
 yum clean all -y

--- a/dockerfiles/almalinux-8
+++ b/dockerfiles/almalinux-8
@@ -19,10 +19,7 @@
 
 FROM almalinux:8
 
-# Install Java
-ENV JAVA_HOME=/opt/java/openjdk
-COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
-ENV PATH="${JAVA_HOME}/bin:${PATH}"
+# Java 21 installed via RPM: java-21-openjdk-devel
 
 # These are needed for the Clouseau integration
 ENV CLOUSEAU_JAVA_HOME=/opt/java/openjdk8

--- a/dockerfiles/almalinux-9
+++ b/dockerfiles/almalinux-9
@@ -19,10 +19,7 @@
 
 FROM almalinux:9
 
-# Install Java
-ENV JAVA_HOME=/opt/java/openjdk
-COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
-ENV PATH="${JAVA_HOME}/bin:${PATH}"
+# Java 21 installed via RPM: java-21-openjdk-devel
 
 # These are needed for the Clouseau integration
 ENV CLOUSEAU_JAVA_HOME=/opt/java/openjdk8


### PR DESCRIPTION
All supported rpm distros seems to have it.

Since something else seems to bring in java 8 rpm we uninstall it at the end leaving just the 21 as the default and the java 8 jre installed from docker (for clouseau).