### PR TITLE
Allow Elixir install for non-Jenkins users

### DIFF
--- a/bin/install-elixir.sh
+++ b/bin/install-elixir.sh
@@ -70,9 +70,5 @@ rm elixir.zip
 # it may be called without a preceding configure call, for instance when
 # building packages from a dist tarball. So we ensure it has hex there already.
 echo "===> Installing Hex"
-MIX_HOME=/home/jenkins/.mix /usr/local/bin/mix local.hex --force
-if id jenkins >/dev/null 2>&1; then
-  chown -R jenkins:jenkins /home/jenkins
-else
-  echo 'no jenkins user'
-fi
+MIX_HOME=${HOME}.mix /usr/local/bin/mix local.hex --force
+chown -R $(whoami):$(whoami) ${HOME}

--- a/bin/install-elixir.sh
+++ b/bin/install-elixir.sh
@@ -71,4 +71,8 @@ rm elixir.zip
 # building packages from a dist tarball. So we ensure it has hex there already.
 echo "===> Installing Hex"
 MIX_HOME=/home/jenkins/.mix /usr/local/bin/mix local.hex --force
-chown -R jenkins:jenkins /home/jenkins
+if id jenkins >/dev/null 2>&1; then
+  chown -R jenkins:jenkins /home/jenkins
+else
+  echo 'no jenkins user'
+fi


### PR DESCRIPTION
In https://github.com/apache/couchdb-ci/pull/73 there was a change to install Hex as part of installing Elixir. There is then a step to `chown` the home directory, presumably because of files added by that install.

However, this broke our pipeline because we use `install-elixir.sh` when building a container image (so in a Dockerfile) in our pipeline, and so the user running the script is _not_ `jenkins`.

So I've updated the script to support other users running the script, testing the fork in our pipeline.