### PR TITLE
The upstream FIPS bug is fixed

### DIFF
--- a/bin/source-erlang.sh
+++ b/bin/source-erlang.sh
@@ -80,23 +80,12 @@ else
     DISABLE_JIT=""
 fi
 
-if [[ ${ERLANGMAJORVERSION} -gt 25 ]]; then
-    echo "*************************  WARNING ***************************"
-    echo "As of 2024-07-11 Erlang 26.2.5* fails access any crypto functions"
-    echo "on OSes with OpenSSL 3.0.x (Debian Bookworm, at least) if the "
-    echo "--enable-fips flag is enabled. See: github.com/erlang/otp/issues/8562"
-    echo "**************************************************************"
-    ENABLE_FIPS=""
-else
-    ENABLE_FIPS="--enable-fips"
-fi
-
 # Configure Erlang - skip building things we don't want or need
 ./configure \
   --without-javac --without-wx --without-odbc \
   --without-debugger --without-observer --without-et  \
   --without-diameter --without-megaco --without-tftp \
-  --without-ftp \
+  --without-ftp --enable-fips \
   ${ENABLE_FIPS} ${DISABLE_JIT}
 
 make -j $(nproc)

--- a/pull-all-couchdbdev-docker
+++ b/pull-all-couchdbdev-docker
@@ -5,7 +5,8 @@ DOCKER_ORG="apache"
 # These are the images that are currently being used, so don't `docker rmi` them on cleanup.
 KEEP_IMAGES=(
 couchdbci-debian:bookworm-erlang-25.3.2.13
-couchdbci-debian:bookworm-erlang-26.2.5.2
+couchdbci-debian:bookworm-erlang-26.2.5.4
+couchdbci-debian:bookworm-erlang:27.1.1
 couchdbci-centos:9-erlang-25.3.2.13
 couchdbci-centos:8-erlang-25.3.2.13
 couchdbci-ubuntu:jammy-erlang-25.3.2.13


### PR DESCRIPTION
Try to build with `--enable-fips` option again


Trying
```
ERLANGVERSION=26.2.5.4 ./build.sh buildx-platform debian-bookworm
```

Then will need to see if crypto functions work.