### PR TITLE
Update OTP default versions in dockerfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ After building the image as above:
 docker run -it couchdbdev/<tag>
 ```
 
-where `<tag>` is of the format `<distro>-<version>-<type>`, such as `debian-bookworm-erlang-25.3.2.15`.
+where `<tag>` is of the format `<distro>-<version>-<type>`, such as `debian-bookworm-erlang-25.3.2.18`.
 
 ## Running the CouchDB build in a published container
 

--- a/dockerfiles/almalinux-8
+++ b/dockerfiles/almalinux-8
@@ -31,7 +31,7 @@ ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
-ARG erlangversion=25.3.2.15
+ARG erlangversion=25.3.2.18
 ARG elixirversion=v1.17.3
 ARG nodeversion=20
 

--- a/dockerfiles/almalinux-9
+++ b/dockerfiles/almalinux-9
@@ -31,7 +31,7 @@ ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
-ARG erlangversion=25.3.2.15
+ARG erlangversion=25.3.2.18
 ARG elixirversion=v1.17.3
 ARG nodeversion=20
 

--- a/dockerfiles/debian-bookworm
+++ b/dockerfiles/debian-bookworm
@@ -36,7 +36,7 @@ ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir
-ARG erlangversion=25.3.2.15
+ARG erlangversion=25.3.2.18
 ARG elixirversion=v1.17.3
 ARG nodeversion=20
 

--- a/dockerfiles/debian-bullseye
+++ b/dockerfiles/debian-bullseye
@@ -36,7 +36,7 @@ ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir
-ARG erlangversion=25.3.2.15
+ARG erlangversion=25.3.2.18
 ARG elixirversion=v1.17.3
 ARG nodeversion=20
 

--- a/dockerfiles/ubuntu-focal
+++ b/dockerfiles/ubuntu-focal
@@ -34,7 +34,7 @@ ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
-ARG erlangversion=25.3.2.15
+ARG erlangversion=25.3.2.18
 ARG elixirversion=v1.17.3
 ARG nodeversion=20
 

--- a/dockerfiles/ubuntu-jammy
+++ b/dockerfiles/ubuntu-jammy
@@ -34,7 +34,7 @@ ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
-ARG erlangversion=25.3.2.15
+ARG erlangversion=25.3.2.18
 ARG elixirversion=v1.17.3
 ARG nodeversion=20
 

--- a/dockerfiles/ubuntu-noble
+++ b/dockerfiles/ubuntu-noble
@@ -34,7 +34,7 @@ ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
-ARG erlangversion=25.3.2.15
+ARG erlangversion=25.3.2.18
 ARG elixirversion=v1.17.3
 ARG nodeversion=20
 

--- a/pull-all-couchdbdev-docker
+++ b/pull-all-couchdbdev-docker
@@ -4,14 +4,14 @@ DOCKER_ORG="apache"
 
 # These are the images that are currently being used, so don't `docker rmi` them on cleanup.
 KEEP_IMAGES=(
-couchdbci-debian:bookworm-erlang-25.3.2.15
+couchdbci-debian:bookworm-erlang-25.3.2.18
 couchdbci-debian:bookworm-erlang-26.2.5.4
 couchdbci-debian:bookworm-erlang:27.1.1
-couchdbci-centos:9-erlang-25.3.2.15
-couchdbci-centos:8-erlang-25.3.2.15
-couchdbci-ubuntu:noble-erlang-25.3.2.15
-couchdbci-ubuntu:jammy-erlang-25.3.2.15
-couchdbci-ubuntu:focal-erlang-25.3.2.15
+couchdbci-centos:9-erlang-25.3.2.18
+couchdbci-centos:8-erlang-25.3.2.18
+couchdbci-ubuntu:noble-erlang-25.3.2.18
+couchdbci-ubuntu:jammy-erlang-25.3.2.18
+couchdbci-ubuntu:focal-erlang-25.3.2.18
 )
 
 for image in ${KEEP_IMAGES[*]}


### PR DESCRIPTION
The updated value images are already built since this version was passed in as an env var but let's update the defaults as well before we forget.