### PR TITLE
Use built-in zlib for erlang

### DIFF
--- a/bin/source-erlang.sh
+++ b/bin/source-erlang.sh
@@ -82,6 +82,7 @@ fi
 
 # Configure Erlang - skip building things we don't want or need
 ./configure \
+  --enable-builtin-zlib \
   --without-javac --without-wx --without-odbc \
   --without-debugger --without-observer --without-et  \
   --without-diameter --without-megaco --without-tftp \

--- a/dockerfiles/almalinux-10
+++ b/dockerfiles/almalinux-10
@@ -21,11 +21,6 @@ FROM almalinux:10
 
 # Java 21 installed via RPM: java-21-openjdk-devel
 
-# These are needed for the Clouseau integration
-# This is the same as for Nouveau for the moment, but perhaps it is better to
-# keep it separate as there is no guarantee that they will be bumped at the
-# same pace.
-ENV CLOUSEAU_JAVA_HOME="${JAVA_HOME}"
 ENV PATH=/usr/local/lib/erlang/bin:"${PATH}"
 
 # Choose whether to install SpiderMonkey 1.8.5, default yes

--- a/dockerfiles/almalinux-8
+++ b/dockerfiles/almalinux-8
@@ -21,11 +21,6 @@ FROM almalinux:8
 
 # Java 21 installed via RPM: java-21-openjdk-devel
 
-# These are needed for the Clouseau integration
-# This is the same as for Nouveau for the moment, but perhaps it is better to
-# keep it separate as there is no guarantee that they will be bumped at the
-# same pace.
-ENV CLOUSEAU_JAVA_HOME="${JAVA_HOME}"
 ENV PATH=/usr/local/lib/erlang/bin:"${PATH}"
 
 # Choose whether to install SpiderMonkey 1.8.5, default yes

--- a/dockerfiles/almalinux-9
+++ b/dockerfiles/almalinux-9
@@ -21,11 +21,6 @@ FROM almalinux:9
 
 # Java 21 installed via RPM: java-21-openjdk-devel
 
-# These are needed for the Clouseau integration
-# This is the same as for Nouveau for the moment, but perhaps it is better to
-# keep it separate as there is no guarantee that they will be bumped at the
-# same pace.
-ENV CLOUSEAU_JAVA_HOME="${JAVA_HOME}"
 ENV PATH=/usr/local/lib/erlang/bin:"${PATH}"
 
 # Choose whether to install SpiderMonkey 1.8.5, default yes


### PR DESCRIPTION
Otherwise some distros like Almalinux use zlib-ng which may be faster and better but it produces slightly different compression lengths for attachments in some tests.

Also cleanup unused couseau_java_home var. We don't set a java_home so the clouseau one is also undefined.