### PR TITLE
Fix image puller

### DIFF
--- a/pull-all-couchdbdev-docker
+++ b/pull-all-couchdbdev-docker
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-DOCKER_ORG="apache"
-
 # These are the images that are currently being used. Make sure we pull them to
 # prefill the local docker images so CI runs a bit quicker. The buildkit image
 # is from docker buildx so that the worker nodes can be used as part of docker
@@ -9,22 +7,22 @@ DOCKER_ORG="apache"
 # --bootstrap` pulls.
 
 PULL_IMAGES=(
-couchdbci-debian:bookworm-erlang:28.3.2
-couchdbci-debian:bookworm-erlang:27.3.4.8
-couchdbci-debian:bookworm-erlang-26.2.5.17
-couchdbci-debian:bullseye-erlang:26.2.5.17
-couchdbci-debian:trixie-erlang:26.2.5.17
-couchdbci-ubuntu:noble-erlang-26.2.5.17
-couchdbci-ubuntu:jammy-erlang-26.2.5.17
-couchdbci-centos:10-erlang-26.2.5.17
-couchdbci-centos:9-erlang-26.2.5.17
-couchdbci-centos:8-erlang-26.2.5.17
+apache/couchdbci-debian:bookworm-erlang:28.3.2
+apache/couchdbci-debian:bookworm-erlang:27.3.4.8
+apache/couchdbci-debian:bookworm-erlang-26.2.5.17
+apache/couchdbci-debian:bullseye-erlang:26.2.5.17
+apache/couchdbci-debian:trixie-erlang:26.2.5.17
+apache/couchdbci-ubuntu:noble-erlang-26.2.5.17
+apache/couchdbci-ubuntu:jammy-erlang-26.2.5.17
+apache/couchdbci-centos:10-erlang-26.2.5.17
+apache/couchdbci-centos:9-erlang-26.2.5.17
+apache/couchdbci-centos:8-erlang-26.2.5.17
 moby/buildkit:buildx-stable-1
 )
 
 docker system prune -af --filter "until=720h"
 for image in ${PULL_IMAGES[*]}
 do
-    echo docker pull ${DOCKER_ORG}/${image}
-    docker pull ${DOCKER_ORG}/${image}
+    echo docker pull ${image}
+    docker pull ${image}
 done


### PR DESCRIPTION
Use an explicit org name instead of DOCKER_ORG="apache" otherwise we'd have to make an exception for moby/buildkit:buildx-stable-1 which doesn't get the `apache/` prefix.