### PR TITLE
Update all Erlang images to latest OTP 27, 28 and 29

### DIFF
--- a/dockerfiles/almalinux-10
+++ b/dockerfiles/almalinux-10
@@ -23,12 +23,15 @@ FROM almalinux:10
 
 ENV PATH=/usr/local/lib/erlang/bin:"${PATH}"
 
+# set UTF-8 as default locale
+ENV LANG=C.UTF-8
+
 # Choose whether to install SpiderMonkey 1.8.5, default yes
 ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
-ARG erlangversion=26.2.5.20
+ARG erlangversion=27.3.4.13
 ARG elixirversion=v1.18.4
 ARG nodeversion=24
 

--- a/dockerfiles/almalinux-8
+++ b/dockerfiles/almalinux-8
@@ -23,12 +23,15 @@ FROM almalinux:8
 
 ENV PATH=/usr/local/lib/erlang/bin:"${PATH}"
 
+# set UTF-8 as default locale
+ENV LANG=C.UTF-8
+
 # Choose whether to install SpiderMonkey 1.8.5, default yes
 ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
-ARG erlangversion=26.2.5.20
+ARG erlangversion=27.3.4.13
 ARG elixirversion=v1.18.4
 ARG nodeversion=24
 

--- a/dockerfiles/almalinux-9
+++ b/dockerfiles/almalinux-9
@@ -23,12 +23,15 @@ FROM almalinux:9
 
 ENV PATH=/usr/local/lib/erlang/bin:"${PATH}"
 
+# set UTF-8 as default locale
+ENV LANG=C.UTF-8
+
 # Choose whether to install SpiderMonkey 1.8.5, default yes
 ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
-ARG erlangversion=26.2.5.20
+ARG erlangversion=27.3.4.13
 ARG elixirversion=v1.18.4
 ARG nodeversion=24
 

--- a/dockerfiles/debian-bookworm
+++ b/dockerfiles/debian-bookworm
@@ -26,6 +26,9 @@ ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=eclipse-temurin:21 $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
+# set UTF-8 as default locale
+ENV LANG=C.UTF-8
+
 # These are needed for the Clouseau integration
 # This is the same as for Nouveau for the moment, but perhaps it is better to
 # keep it separate as there is no guarantee that they will be bumped at the
@@ -38,7 +41,7 @@ ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir
-ARG erlangversion=26.2.5.20
+ARG erlangversion=27.3.4.13
 ARG elixirversion=v1.18.4
 ARG nodeversion=24
 

--- a/dockerfiles/debian-bullseye
+++ b/dockerfiles/debian-bullseye
@@ -26,6 +26,9 @@ ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=eclipse-temurin:21 $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
+# set UTF-8 as default locale
+ENV LANG=C.UTF-8
+
 # These are needed for the Clouseau integration
 # This is the same as for Nouveau for the moment, but perhaps it is better to
 # keep it separate as there is no guarantee that they will be bumped at the
@@ -38,7 +41,7 @@ ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir
-ARG erlangversion=26.2.5.20
+ARG erlangversion=27.3.4.13
 ARG elixirversion=v1.18.4
 ARG nodeversion=24
 

--- a/dockerfiles/debian-trixie
+++ b/dockerfiles/debian-trixie
@@ -26,6 +26,9 @@ ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=eclipse-temurin:21 $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
+# set UTF-8 as default locale
+ENV LANG=C.UTF-8
+
 # These are needed for the Clouseau integration
 # This is the same as for Nouveau for the moment, but perhaps it is better to
 # keep it separate as there is no guarantee that they will be bumped at the
@@ -38,7 +41,7 @@ ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir
-ARG erlangversion=26.2.5.20
+ARG erlangversion=27.3.4.13
 ARG elixirversion=v1.18.4
 ARG nodeversion=24
 

--- a/dockerfiles/ubuntu-jammy
+++ b/dockerfiles/ubuntu-jammy
@@ -24,6 +24,9 @@ ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=eclipse-temurin:21 $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
+# set UTF-8 as default locale
+ENV LANG=C.UTF-8
+
 # These are needed for the Clouseau integration
 # This is the same as for Nouveau for the moment, but perhaps it is better to
 # keep it separate as there is no guarantee that they will be bumped at the
@@ -36,7 +39,7 @@ ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
-ARG erlangversion=26.2.5.20
+ARG erlangversion=27.3.4.13
 ARG elixirversion=v1.18.4
 ARG nodeversion=24
 

--- a/dockerfiles/ubuntu-noble
+++ b/dockerfiles/ubuntu-noble
@@ -24,6 +24,9 @@ ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=eclipse-temurin:21 $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
+# set UTF-8 as default locale
+ENV LANG=C.UTF-8
+
 # These are needed for the Clouseau integration
 # This is the same as for Nouveau for the moment, but perhaps it is better to
 # keep it separate as there is no guarantee that they will be bumped at the
@@ -36,7 +39,7 @@ ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
-ARG erlangversion=26.2.5.20
+ARG erlangversion=27.3.4.13
 ARG elixirversion=v1.18.4
 ARG nodeversion=24
 

--- a/dockerfiles/ubuntu-resolute
+++ b/dockerfiles/ubuntu-resolute
@@ -31,12 +31,15 @@ ENV PATH="${JAVA_HOME}/bin:${PATH}"
 ENV CLOUSEAU_JAVA_HOME="${JAVA_HOME}"
 ENV PATH=/usr/local/lib/erlang/bin:"${PATH}"
 
+# set UTF-8 as default locale
+ENV LANG=C.UTF-8
+
 # Choose whether to install SpiderMonkey 1.8.5, default yes
 ARG js=js
 # Choose whether to install Erlang, default yes
 ARG erlang=erlang
 # Select version of Node, Erlang and Elixir to install
-ARG erlangversion=26.2.5.20
+ARG erlangversion=27.3.4.13
 ARG elixirversion=v1.18.4
 ARG nodeversion=24
 

--- a/pull-all-couchdbdev-docker
+++ b/pull-all-couchdbdev-docker
@@ -7,17 +7,17 @@
 # --bootstrap` pulls.
 
 PULL_IMAGES=(
-apache/couchdbci-debian:bookworm-erlang:28.3.2
-apache/couchdbci-debian:bookworm-erlang:27.3.4.8
-apache/couchdbci-debian:bookworm-erlang-26.2.5.20
-apache/couchdbci-debian:bullseye-erlang:26.2.5.20
-apache/couchdbci-debian:trixie-erlang:26.2.5.20
-apache/couchdbci-ubuntu:resolute-erlang-26.2.5.20
-apache/couchdbci-ubuntu:noble-erlang-26.2.5.20
-apache/couchdbci-ubuntu:jammy-erlang-26.2.5.20
-apache/couchdbci-centos:10-erlang-26.2.5.20
-apache/couchdbci-centos:9-erlang-26.2.5.20
-apache/couchdbci-centos:8-erlang-26.2.5.20
+apache/couchdbci-debian:bookworm-erlang:29.0.2
+apache/couchdbci-debian:bookworm-erlang:28.5.0.2
+apache/couchdbci-debian:bookworm-erlang-27.3.4.13
+apache/couchdbci-debian:bullseye-erlang:27.3.4.13
+apache/couchdbci-debian:trixie-erlang:27.3.4.13
+apache/couchdbci-ubuntu:resolute-erlang-27.3.4.13
+apache/couchdbci-ubuntu:noble-erlang-27.3.4.13
+apache/couchdbci-ubuntu:jammy-erlang-27.3.4.13
+apache/couchdbci-centos:10-erlang-27.3.4.13
+apache/couchdbci-centos:9-erlang-27.3.4.13
+apache/couchdbci-centos:8-erlang-27.3.4.13
 moby/buildkit:buildx-stable-1
 )
 


### PR DESCRIPTION
27.3.4.13
28.5.0.2
29.0.2

 * https://hub.docker.com/repository/docker/apache/couchdbci-centos/tags
 * https://hub.docker.com/repository/docker/apache/couchdbci-debian/tags
 * https://hub.docker.com/repository/docker/apache/couchdbci-ubuntu/tags