### PR TITLE
Add Spidermonkey v140 to Ubuntu 26.04

### DIFF
--- a/bin/apt-dependencies.sh
+++ b/bin/apt-dependencies.sh
@@ -136,7 +136,7 @@ fi
 if [ "$1" != "nojs" ]; then
   # newer releases have newer libmozjs
   if [ "${VERSION_CODENAME}" == "resolute" ]; then
-      apt-get install --no-install-recommends -y libmozjs-128-dev
+      apt-get install --no-install-recommends -y libmozjs-128-dev libmozjs-140-dev
   fi
   if [ "${VERSION_CODENAME}" == "noble" ]; then
     apt-get install --no-install-recommends -y libmozjs-102-dev libmozjs-115-dev


### PR DESCRIPTION
Have the ability to link against Spidermonkey v140, if CouchDB will ever support this version.